### PR TITLE
Dhalperi refactor traversal to algebra.operator

### DIFF
--- a/raco/algebra.py
+++ b/raco/algebra.py
@@ -46,6 +46,14 @@ class Operator(Printable):
       for x in c.postorder(f):
         yield x
 
+  def collectParents(self, parent_map=None):
+    """Construct a dict mapping children to parents. Used in optimization"""
+    if parent_map is None:
+      parent_map = {}
+    for c in self.children():
+      parent_map.setdefault(c, []).append(self)
+      c.collectParents(parentmap)
+
   def __eq__(self, other):
     return self.__class__ == other.__class__
 
@@ -143,9 +151,6 @@ class ZeroaryOperator(Operator):
     """Deep copy"""
     Operator.copy(self, other)
 
-  def collectParents(self, parentmap):
-    pass
-
 class UnaryOperator(Operator):
   """Operator with one argument"""
   def __init__(self, input):
@@ -194,11 +199,6 @@ class UnaryOperator(Operator):
     self.input = other.input
     Operator.copy(self, other)
 
-  def collectParents(self, parentmap):
-    """Construct a dict mapping children to parents. Used in optimization"""
-    parentmap.setdefault(self.input, []).append(self)
-    self.input.collectParents(parentmap)
-
 class BinaryOperator(Operator):
   """Operator with two arguments"""
   def __init__(self, left, right):
@@ -242,13 +242,6 @@ class BinaryOperator(Operator):
     self.right = other.right
     Operator.copy(self, other)
 
-  def collectParents(self, parentmap):
-    """Construct a dict mapping children to parents. Used in optimization."""
-    parentmap.setdefault(self.left, []).append(self)
-    parentmap.setdefault(self.right, []).append(self)
-    self.left.collectParents(parentmap)
-    self.right.collectParents(parentmap)
-
 class NaryOperator(Operator):
   """Operator with N arguments.  e.g., multi-way joins in one step."""
   def __init__(self, args):
@@ -282,12 +275,6 @@ class NaryOperator(Operator):
     """deep copy"""
     self.args = [a for a in other.args]
     Operator.copy(self, other)
-
-  def collectParents(self, parentmap):
-    """Construct a dict mapping children to parents. Used in optimization."""
-    for arg in self.args:
-      parentmap.setdefault(arg, []).append(self)
-      arg.collectParents(parentmap)
 
   def apply(self, f):
     """Apply a function to your children"""


### PR DESCRIPTION
@billhowe , this is a simple set of two patches to move traversals up into the `algebra.Operator` class from `algebra.ZeroaryOperator`, `algebra.UnaryOperator`, etc.

I was going to move `.apply(self, f)` as well but I'm concerned it doesn't work. What if an operator needs to do something, e.g., recalculate its scheme, after the change? [Is it the case that none of these types of references are positional?]

Dan
