### PR TITLE
Add constants (table literals) to myrial

### DIFF
--- a/raco/algebra.py
+++ b/raco/algebra.py
@@ -671,7 +671,6 @@ class SingletonRelation(ZeroaryOperator):
     """scheme of the result."""
     return scheme.Scheme()
 
-
 class Scan(ZeroaryOperator):
   """Logical Scan operator"""
   def __init__(self, relation=None):

--- a/raco/fakedb.py
+++ b/raco/fakedb.py
@@ -3,7 +3,7 @@ import collections
 import itertools
 
 import raco.algebra
-import raco.scheme as scheme
+import raco.scheme
 
 class FakeDatabase:
     """An in-memory implementation of relational algebra operators"""

--- a/raco/myrial/interpreter.py
+++ b/raco/myrial/interpreter.py
@@ -4,6 +4,7 @@ import raco.myrial.parser as parser
 import raco.algebra
 import raco.expression as colexpr
 import raco.catalog
+import raco.scheme
 
 import collections
 import random
@@ -33,8 +34,9 @@ class ExpressionProcessor:
     def load(self, path, schema):
         raise NotImplementedError()
 
-    def table(self, tuple_list, schema):
-        raise NotImplementedError()
+    def table(self, mappings):
+        op = raco.algebra.SingletonRelation()
+        return raco.algebra.Apply(mappings=mappings, input=op)
 
     def bagcomp(self, from_expression, where_clause, emit_clause):
         # Evaluate the nested expression to get a RA operator

--- a/raco/myrial/parser.py
+++ b/raco/myrial/parser.py
@@ -91,6 +91,10 @@ class Parser:
         'expression : ID'
         p[0] = ('ALIAS', p[1])
 
+    def p_expression_table_literal(self, p):
+        'expression : LBRACKET emit_arg_list RBRACKET'
+        p[0] = ('TABLE', p[2])
+
     def p_expression_scan(self, p):
         'expression : SCAN LPAREN relation_key optional_schema RPAREN'
         # TODO(AJW): Nix optional schema argument once we can read this from

--- a/raco/myrial/query_tests.py
+++ b/raco/myrial/query_tests.py
@@ -365,6 +365,5 @@ class TestQueryFunctions(unittest.TestCase):
         X = [FROM ["Andrew", salary=(50 * (500 + 500))] EMIT salary];
         DUMP(X);
         """
-
         expected = collections.Counter([(50000,)])
-        self.__run_test(query, expected);
+        self.__run_test(query, expected)


### PR DESCRIPTION
This uses the bracket syntax favored by Dan (and probably everyone else):

Constants = [x=3, y="Hello World"];

There is no way to declare a multi-row table literal -- problem for another day.
