### PR TITLE
heuristic try to break cycles with != edges when building logical RA

### DIFF
--- a/raco/datalog/model.py
+++ b/raco/datalog/model.py
@@ -316,6 +316,7 @@ class Rule(object):
                         data = component.get_edge_data(*oneedge)
                         condition = data['condition']
                         if isinstance(condition, expression.NEQ):
+                            #TODO: What I actually want is NEQ || conjunction of only NEQs
                             foundPreferredSel = True
                             break
 


### PR DESCRIPTION
The idea is try to avoid putting `!=` in the join conditions.
It is a heuristic sans-statistics assuming that this type of plan will usually be less efficient than another join path.

note that current approach is not efficient because it checks
all cycle edges for a != before giving up. Then again iterative
cycle finding is not as efficient as MST
