### PR TITLE
Change JSON format

### DIFF
--- a/raco/myrialang.py
+++ b/raco/myrialang.py
@@ -1120,7 +1120,7 @@ def compile_to_json(raw_query, logical_plan, physical_plan, catalog=None):
         else:
             raise NotImplementedError("unable to handle operator of type " + type(op))  # noqa
         op_dict['opName'] = op.shortStr()
-        op_dict['opID'] = opsym
+        op_dict['opId'] = opsym
         return op_dict
 
     # The actual code. all_frags collects up the fragments.


### PR DESCRIPTION
This adds an `opId` to replace `opName`. `opName` is now a human readable version.

Myria changes in https://github.com/uwescience/myria/pull/480

``` json
{
  "fragments": [
    {
      "operators": [
        {
          "opName": "MyriaScan(public:adhoc:TwitterK)",
          "opId": "V1",
          "relationKey": {
            "userName": "public",
            "relationName": "TwitterK",
            "programName": "adhoc"
          },
          "opType": "TableScan"
        },
        {
          "opId": "V2",
          "emitExpressions": [
            {
              "outputName": "followee",
              "rootExpressionOperator": {
                "type": "VARIABLE",
                "columnIdx": 0
              }
            }
          ],
          "opName": "MyriaApply(followee=$0)",
          "opType": "Apply",
          "argChild": "V1"
        },
        {
          "relationKey": {
            "userName": "public",
            "relationName": "JustX",
            "programName": "adhoc"
          },
          "opName": "MyriaStore(public:adhoc:JustX)",
          "opType": "DbInsert",
          "argOverwriteTable": true,
          "opId": "V0",
          "argChild": "V2"
        }
      ]
    }
  ],
  "logicalRa": "Sequence[Store(public:adhoc:JustX)[Apply(followee=$0)[Scan(public:adhoc:TwitterK)]]]",
  "rawDatalog": "T1 = SCAN(TwitterK);\n\nT2 = [FROM T1 EMIT $0];\n\nSTORE (T2, JustX);"
}
```
