### PR TITLE
myrialang: re-enable distinct on project

### DIFF
--- a/raco/myrialang.py
+++ b/raco/myrialang.py
@@ -771,12 +771,8 @@ class ProjectToDistinctColumnSelect(rules.Rule):
 
         mappings = [(None, x) for x in expr.columnlist]
         colSelect = algebra.Apply(mappings, expr.input)
-        # TODO(dhalperi) the distinct logic is broken because we don't have a
-        # locality-aware optimizer. For now, don't insert Distinct for a
-        # logical project. This is BROKEN.
-        # distinct = algebra.Distinct(colSelect)
-        # return distinct
-        return colSelect
+        distinct = algebra.Distinct(colSelect)
+        return distinct
 
 
 class SimpleGroupBy(rules.Rule):


### PR DESCRIPTION
We disabled this a long time ago when we were using Datalog as the
only demo language. Now we have MyriaL and SQL where it is easy
and natural to distinguish between set and bag semantics. Thus, add
set semantics back to the Project operator, which fixes Datalog.
