### PR TITLE
Add aql escape syntax to myrial and raco

### DIFF
--- a/raco/algebra.py
+++ b/raco/algebra.py
@@ -1,6 +1,6 @@
 from raco import expression
 from raco import scheme
-from raco.utility import emit, emitlist, Printable
+from raco.utility import *
 
 from abc import ABCMeta, abstractmethod
 import copy
@@ -1123,6 +1123,27 @@ class DoWhile(NaryOperator):
     def scheme(self):
         """DoWhile does not return any tuples."""
         return None
+
+
+class Exec(ZeroaryOperator, CommonEqualityMixin):
+    """Execute an uninterpreted query on the given backend system."""
+
+    def __init__(self, command=None, language=None):
+        """
+        @param command: The query to execute
+        @type command: basestring
+        @param language: The query language of the query
+        @type language: basestring
+        """
+        self.command = command
+        self.language = language
+
+    def copy(self, other):
+        self.command = other.command
+        self.language = language
+
+    def scheme(self):
+        raise SchemaError()
 
 
 def inline_operator(dest_op, var, target_op):

--- a/raco/algebra.py
+++ b/raco/algebra.py
@@ -1142,6 +1142,9 @@ class Exec(ZeroaryOperator, CommonEqualityMixin):
         self.command = other.command
         self.language = language
 
+    def shortStr(self):
+        return "Exec(%s, %s)" % (self.command, self.language)
+
     def scheme(self):
         raise SchemaError()
 

--- a/raco/algebra.py
+++ b/raco/algebra.py
@@ -317,6 +317,10 @@ class NaryOperator(Operator):
         else:
             self.args = args
 
+    def __eq__(self, other):
+        return (self.__class__ == other.__class__
+                and self.args == other.args)
+
     def add(self, op):
         """Add a child operator to the end of the child argument list."""
         self.args.append(op)
@@ -1125,7 +1129,7 @@ class DoWhile(NaryOperator):
         return None
 
 
-class Exec(ZeroaryOperator, CommonEqualityMixin):
+class Exec(ZeroaryOperator):
     """Execute an uninterpreted query on the given backend system."""
 
     def __init__(self, command=None, language=None):
@@ -1137,6 +1141,11 @@ class Exec(ZeroaryOperator, CommonEqualityMixin):
         """
         self.command = command
         self.language = language
+
+    def __eq__(self, other):
+        return self.__class__ == other.__class__ \
+               and self.command == other.command \
+               and self.language == other.language
 
     def copy(self, other):
         self.command = other.command

--- a/raco/algebra.py
+++ b/raco/algebra.py
@@ -1143,9 +1143,9 @@ class Exec(ZeroaryOperator):
         self.language = language
 
     def __eq__(self, other):
-        return self.__class__ == other.__class__ \
-               and self.command == other.command \
-               and self.language == other.language
+        return (self.__class__ == other.__class__
+                and self.command == other.command
+                and self.language == other.language)
 
     def copy(self, other):
         self.command = other.command

--- a/raco/myrial/aql_tests.py
+++ b/raco/myrial/aql_tests.py
@@ -5,13 +5,14 @@ from raco.algebra import *
 from collections import Counter
 from raco.scheme import Scheme
 
+
 class AqlTests(MyrialTestCase):
     def setUp(self):
         super(AqlTests, self).setUp()
         self.db.ingest("public:adhoc:employees", Counter, Scheme())
 
     def test_escaped_aql(self):
-        aql =  'SELECT * FROM TestArray'
+        aql = 'SELECT * FROM TestArray'
         query = "%%aql %s;" % aql
         plan = self.get_plan(query, logical=True)
         expected = Sequence([Exec(aql, "AQL")])
@@ -19,7 +20,7 @@ class AqlTests(MyrialTestCase):
         self.assertEquals(plan, expected)
 
     def test_escaped_aql_with_myrial(self):
-        aql =  'SELECT * FROM TestArray'
+        aql = 'SELECT * FROM TestArray'
         query = """
         %%aql %s;
         X = SCAN(public:adhoc:employees);

--- a/raco/myrial/aql_tests.py
+++ b/raco/myrial/aql_tests.py
@@ -1,0 +1,32 @@
+"""Tests of AQL escaping."""
+
+from raco.myrial.myrial_test import MyrialTestCase
+from raco.algebra import *
+from collections import Counter
+from raco.scheme import Scheme
+
+class AqlTests(MyrialTestCase):
+    def setUp(self):
+        super(AqlTests, self).setUp()
+        self.db.ingest("public:adhoc:employees", Counter, Scheme())
+
+    def test_escaped_aql(self):
+        aql =  'SELECT * FROM TestArray'
+        query = "%%aql %s;" % aql
+        plan = self.get_plan(query, logical=True)
+        expected = Sequence([Exec(aql, "AQL")])
+
+        self.assertEquals(plan, expected)
+
+    def test_escaped_aql_with_myrial(self):
+        aql =  'SELECT * FROM TestArray'
+        query = """
+        %%aql %s;
+        X = SCAN(public:adhoc:employees);
+        STORE(X, OUTPUT);""" % aql
+
+        plan = self.get_plan(query, logical=True)
+
+        self.assertIsInstance(plan, Sequence)
+        self.assertIsInstance(plan.args[0], Exec)
+        self.assertIsInstance(plan.args[1], Store)

--- a/raco/myrial/cfg_test.py
+++ b/raco/myrial/cfg_test.py
@@ -2,13 +2,16 @@
 
 import collections
 
-import raco.myrial.myrial_test as myrial_test
+import unittest
 import raco.scheme as scheme
 from raco import types
+from raco.fakedb import FakeDatabase
+import raco.myrial.parser
+import raco.myrial.interpreter
 import networkx as nx
 
 
-class CFGTest(myrial_test.MyrialTestCase):
+class CFGTest(unittest.TestCase):
     points_table = collections.Counter()
     points_schema = scheme.Scheme([('id', types.LONG_TYPE),
                                    ('x', types.DOUBLE_TYPE),
@@ -16,11 +19,12 @@ class CFGTest(myrial_test.MyrialTestCase):
     points_key = "public:adhoc:points"
 
     def setUp(self):
-        super(CFGTest, self).setUp()
-
+        self.db = FakeDatabase()
         self.db.ingest(CFGTest.points_key,
                        CFGTest.points_table,
                        CFGTest.points_schema)
+        self.parser = raco.myrial.parser.Parser()
+        self.processor = raco.myrial.interpreter.StatementProcessor(self.db)
 
     def test_cfg(self):
         query = """

--- a/raco/myrial/interpreter.py
+++ b/raco/myrial/interpreter.py
@@ -388,6 +388,9 @@ class StatementProcessor(object):
         # loop
         self.cfg.add_edge(last_op_id, first_op_id)
 
+    def aql(self, query):
+        self.cfg.add_op(raco.algebra.Exec(query, "AQL"), None, set())
+
     def get_logical_plan(self):
         """Return an operator representing the logical query plan."""
         return self.cfg.get_logical_plan()

--- a/raco/myrial/myrial_parser.py
+++ b/raco/myrial/myrial_parser.py
@@ -1,0 +1,33 @@
+"""Convert myrial source programs to a plan representation."""
+
+from raco.myrial.parser import Parser
+from raco.myrial.interpreter import StatementProcessor
+
+
+def myrial_to_ast(query, catalog=None):
+    """Produce a myrial AST from a source program."""
+    parser = Parser()
+    processor = StatementProcessor(catalog)
+
+    statements = parser.parse(query)
+    return processor.evaluate(statements)
+
+
+def myrial_to_plan(query, catalog=None, logical=False):
+    parser = Parser()
+    processor = StatementProcessor(catalog)
+
+    statements = parser.parse(query)
+    processor.evaluate(statements)
+    if logical:
+        return processor.get_logical_plan()
+    else:
+        return processor.get_physical_plan()
+
+
+def myrial_to_logical_plan(query, catalog=None):
+    return myrial_to_plan(query, catalog=catalog, logical=True)
+
+
+def myrial_to_physical_plan(query, catalog=None):
+    return myrial_to_plan(query, catalog=catalog, logical=False)

--- a/raco/myrial/myrial_test.py
+++ b/raco/myrial/myrial_test.py
@@ -3,30 +3,21 @@ import unittest
 
 from raco.myrialang import compile_to_json
 import raco.fakedb
-import raco.myrial.interpreter as interpreter
-import raco.myrial.parser as parser
+from raco.myrial.myrial_parser import *
 
 
 class MyrialTestCase(unittest.TestCase):
 
     def setUp(self):
         self.db = raco.fakedb.FakeDatabase()
-        self.parser = parser.Parser()
-        self.processor = interpreter.StatementProcessor(self.db)
 
     def parse(self, query):
         '''Parse a query'''
-        statements = self.parser.parse(query)
-        self.processor.evaluate(statements)
+        return myrial_to_ast(query, catalog=self.db)
 
     def get_plan(self, query, logical=False):
         '''Get the MyriaL query plan for a query'''
-        statements = self.parser.parse(query)
-        self.processor.evaluate(statements)
-        if logical:
-            return self.processor.get_logical_plan()
-        else:
-            return self.processor.get_physical_plan()
+        return myrial_to_plan(query, catalog=self.db, logical=logical)
 
     def get_logical_plan(self, query):
         '''Get the logical plan for a MyriaL query'''

--- a/raco/myrial/optimizer_tests.py
+++ b/raco/myrial/optimizer_tests.py
@@ -290,10 +290,7 @@ class OptimizerTest(myrial_test.MyrialTestCase):
         STORE(U, OUTPUT);
         """
 
-        statements = self.parser.parse(query)
-        self.processor.evaluate(statements)
-
-        lp = self.processor.get_logical_plan()
+        lp = self.get_logical_plan(query)
         self.assertEquals(self.get_count(lp, CrossProduct), 2)
 
         pp = self.logical_to_physical(lp)
@@ -337,9 +334,7 @@ class OptimizerTest(myrial_test.MyrialTestCase):
         T = SCAN(public:adhoc:X);
         STORE(T, OUTPUT, [$2, b]);
         """
-        statements = self.parser.parse(query)
-        self.processor.evaluate(statements)
-        lp = self.processor.get_logical_plan()
+        lp = self.get_logical_plan(query)
 
         self.assertEquals(self.get_count(lp, Shuffle), 1)
 

--- a/raco/myrial/parser.py
+++ b/raco/myrial/parser.py
@@ -98,7 +98,8 @@ class Parser(object):
         '''translation_unit : statement
                             | constant
                             | udf
-                            | apply'''
+                            | apply
+                            | aql'''
         p[0] = p[1]
 
     @staticmethod
@@ -188,6 +189,11 @@ class Parser(object):
         'unreserved_id : ID'
         Parser.check_for_reserved(p, p[1])
         p[0] = p[1]
+
+    @staticmethod
+    def p_aql(p):
+        'aql : AQL'
+        p[0] = ('AQL', p[1])
 
     @staticmethod
     def p_udf(p):

--- a/raco/myrial/reachable_tests.py
+++ b/raco/myrial/reachable_tests.py
@@ -82,11 +82,8 @@ class ReachableTest(myrial_test.MyrialTestCase):
 
             return any(plan.postorder(f))
 
-        statements = self.parser.parse(query)
-        self.processor.evaluate(statements)
-
-        lp = self.processor.get_logical_plan()
+        lp = self.get_logical_plan(query)
         self.assertTrue(plan_contains_cross(lp))
 
-        pp = self.processor.get_physical_plan()
+        pp = self.get_physical_plan(query)
         self.assertFalse(plan_contains_cross(pp))

--- a/raco/myrial/scanner.py
+++ b/raco/myrial/scanner.py
@@ -63,7 +63,7 @@ t_DOLLAR = r'\$'
 
 
 def t_AQL(t):
-    r'%%aql(.|\n)*?;/'
+    r'%aql (.|\n)*?;'
     t.lexer.lineno += t.value.count('\n')
     t.value = t.value[4:-1]
     return t

--- a/raco/myrial/scanner.py
+++ b/raco/myrial/scanner.py
@@ -65,7 +65,7 @@ t_DOLLAR = r'\$'
 def t_AQL(t):
     r'%aql (.|\n)*?;'
     t.lexer.lineno += t.value.count('\n')
-    t.value = t.value[4:-1]
+    t.value = t.value[5:-1]
     return t
 
 

--- a/raco/myrial/scanner.py
+++ b/raco/myrial/scanner.py
@@ -28,7 +28,7 @@ tokens = ['LPAREN', 'RPAREN', 'LBRACKET', 'RBRACKET', 'DOT', 'PLUS', 'MINUS',
           'TIMES', 'DIVIDE', 'IDIVIDE', 'LT', 'GT', 'GE', 'LE', 'EQ', 'NE',
           'NE2', 'COMMA', 'SEMI', 'EQUALS', 'COLON', 'DOLLAR', 'ID',
           'STRING_LITERAL', 'INTEGER_LITERAL', 'FLOAT_LITERAL', 'LBRACE',
-          'RBRACE'] + reserved
+          'RBRACE', 'AQL'] + reserved
 
 # Regular expression rules for simple tokens
 t_LPAREN = r'\('
@@ -60,6 +60,13 @@ t_COLON = r':'
 t_DOLLAR = r'\$'
 
 # Regular expressions for non-trivial tokens
+
+
+def t_AQL(t):
+    r'%%aql(.|\n)*?;/'
+    t.lexer.lineno += t.value.count('\n')
+    t.value = t.value[4:-1]
+    return t
 
 
 def t_ID(t):


### PR DESCRIPTION
Syntax like the following is supported:

```
%aql select * from MyArray;
X = Scan() -- Normal Myrial code
```