### PR TITLE
raco: support an AppendTemp operator

### DIFF
--- a/raco/algebra.py
+++ b/raco/algebra.py
@@ -1306,7 +1306,35 @@ class StoreTemp(UnaryOperator):
         return self.input.num_tuples()
 
     def shortStr(self):
-        return 'StoreTemp(%s)' % self.name
+        return '{op}({name})'.format(op=self.opname(), name=self.name)
+
+    def copy(self, other):
+        self.name = other.name
+        UnaryOperator.copy(self, other)
+
+    def __eq__(self, other):
+        return UnaryOperator.__eq__(self, other) and self.name == other.name
+
+    def __repr__(self):
+        return "{op}({name!r}, {inp!r})".format(op=self.opname(),
+                                                name=self.name,
+                                                inp=self.input)
+
+
+class AppendTemp(UnaryOperator):
+    """Append an input relation to a "temporary" relation.
+
+    Temporary relations exist for the lifetime of a query.
+    """
+    def __init__(self, name=None, input=None):
+        UnaryOperator.__init__(self, input)
+        self.name = name
+
+    def num_tuples(self):
+        return self.input.num_tuples()
+
+    def shortStr(self):
+        return '{op}({name})'.format(op=self.opname(), name=self.name)
 
     def copy(self, other):
         self.name = other.name

--- a/raco/fakedb.py
+++ b/raco/fakedb.py
@@ -342,6 +342,10 @@ class FakeDatabase(Catalog):
         bag = self.evaluate_to_bag(op.input)
         self.temp_tables[op.name] = bag
 
+    def appendtemp(self, op):
+        bag = self.evaluate_to_bag(op.input)
+        self.temp_tables[op.name].update(bag)
+
     def scantemp(self, op):
         bag = self.temp_tables[op.name]
         return bag.elements()
@@ -374,6 +378,9 @@ class FakeDatabase(Catalog):
 
     def myriastoretemp(self, op):
         return self.storetemp(op)
+
+    def myriaappendtemp(self, op):
+        return self.appendtemp(op)
 
     def myriaapply(self, op):
         return self.apply(op)


### PR DESCRIPTION
AppendTemp is like StoreTemp except that it appends tuples. For now, at
least on the Myria backend, we only support Appending to temporary
relations so that the query-level fault tolerance issues are elided.

Also add a rule to Myrialang to map StoreTemp(UnionAll(ScanTemp, ..)) to
an AppendTemp on the final Myria physical plans.
