### PR TITLE
one or maybe more fixes for grappa tests

### DIFF
--- a/c_test_environment/grappalang_tests.py
+++ b/c_test_environment/grappalang_tests.py
@@ -16,10 +16,10 @@ from emitcode import emitCode
 
 class DatalogGrappaTest(unittest.TestCase, DatalogPlatformTest):
     def check(self, query, name):
-        emitCode(query, 'grappa_%s' % name, GrappaAlgebra, dir='c_test_environment')
-        # TODO actually be able to check the query
-        raise SkipTest(query)
         with Chdir("c_test_environment") as d:
+            emitCode(query, 'grappa_%s' % name, GrappaAlgebra)
+            # TODO actually be able to check the query
+            raise SkipTest(query)
             checkquery(name, GrappalangRunner())
 
     def check_file(self, query, name):


### PR DESCRIPTION
- [x] move generated logical.dot and physical.dot files to the `c_test_environment` directory.
- [ ] fix the errors on `D2` and `D3` seen on my machine and @stechu's but not Travis-CI.

FYI @bmyerz , though I do not need your cycles.
