### PR TITLE
jinja2 is required to launch raco, so include it in setup

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,5 +6,4 @@ flake8 == 2.1.0
 pep8 == 1.5.4
 pyflakes == 0.8.1
 mccabe == 0.2.1
-jinja2 == 2.7.3
 # /Flake8

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,6 @@ setup(name='raco',
       url='https://github.com/uwescience/raco',
       packages=find_packages(exclude=['clang']),
       package_data={'': ['c_templates/*.template','grappa_templates/*.template']},
-      install_requires=['networkx', 'ply', 'pyparsing', 'SQLAlchemy'],
+      install_requires=['networkx', 'ply', 'pyparsing', 'SQLAlchemy', 'jinja2'],
       scripts=['scripts/myrial']
       )


### PR DESCRIPTION
Not just dev requirements. 
