### PR TITLE
Simplify design, implementation of unboxing in Myrial

### DIFF
--- a/examples/reachable.myl
+++ b/examples/reachable.myl
@@ -9,6 +9,6 @@ DO
                               EMIT Edge.dst AS addr]);
     Delta = DIFF(NewlyReachable, Reachable);
     Reachable = UNIONALL(Delta, Reachable);
-WHILE [*COUNTALL(Delta) > 0];
+WHILE [FROM COUNTALL(Delta) AS size EMIT *size > 0];
 
 STORE(Reachable, OUTPUT);

--- a/raco/expression/expression.py
+++ b/raco/expression/expression.py
@@ -564,15 +564,15 @@ class NEG(UnaryOperator):
 
 class Unbox(ZeroaryOperator):
 
-    def __init__(self, relational_expression, field):
+    def __init__(self, table_name, field):
         """Initialize an unbox expression.
 
-        relational_expression is a Myrial AST that evaluates to a relation.
-
-        field is an optional column name/index within the relation.  If None,
-        the system uses index 0.
+        :param table_name: The name of a table (a string).
+        :param field: An optional column name/index within the relation.
+        If None, the system uses index 0.
         """
-        self.relational_expression = relational_expression
+        assert isinstance(table_name, str)
+        self.table_name = table_name
         self.field = field
 
     def evaluate(self, _tuple, scheme, state=None):
@@ -588,11 +588,11 @@ class Unbox(ZeroaryOperator):
 
     def __repr__(self):
         return "{op}({re!r}, {f!r})".format(
-            op=self.opname(), re=self.relational_expression, f=self.field)
+            op=self.opname(), re=self.table_name, f=self.field)
 
     def __str__(self):
         return "{op}({re}.{f})".format(
-            op=self.opname(), re=self.relational_expression,
+            op=self.opname(), re=self.table_name,
             f=self.field or "$0")
 
 

--- a/raco/expression/expression.py
+++ b/raco/expression/expression.py
@@ -568,8 +568,7 @@ class DottedRef(ZeroaryOperator):
     def __init__(self, table_alias, field):
         """Initialize an DottedRef expression.
 
-        :param table_alias: The name of a table alias, as given in the from
-        clause.
+        :param table_alias: The name of a table alias (a string).
         :param field: The column name/index within the relation.
         """
         assert isinstance(table_alias, str)
@@ -596,8 +595,10 @@ class DottedRef(ZeroaryOperator):
             op=self.opname(), re=self.table_alias, f=self.field)
 
 
-class Unbox(ZeroaryOperator):
-
+class Unbox(DottedRef):
+    """Unbox expressions act as a DottedRef, but also implicitly add their
+    target argument to the FROM clause.
+    """
     def __init__(self, table_name, field):
         """Initialize an unbox expression.
 
@@ -605,9 +606,10 @@ class Unbox(ZeroaryOperator):
         :param field: An optional column name/index within the relation.
         If None, the system uses index 0.
         """
-        assert isinstance(table_name, str)
+        DottedRef.__init__(self, table_name, field or 0)
+
+        # Name == Alias for unbox expressions
         self.table_name = table_name
-        self.field = field
 
     def evaluate(self, _tuple, scheme, state=None):
         """Raise an error on attempted evaluation.

--- a/raco/expression/expression.py
+++ b/raco/expression/expression.py
@@ -562,6 +562,40 @@ class NEG(UnaryOperator):
         return input_type
 
 
+class DottedRef(ZeroaryOperator):
+    """A DottedRef represents a reference to a column from a given table."""
+
+    def __init__(self, table_alias, field):
+        """Initialize an DottedRef expression.
+
+        :param table_alias: The name of a table alias, as given in the from
+        clause.
+        :param field: The column name/index within the relation.
+        """
+        assert isinstance(table_alias, str)
+        self.table_alias = table_alias
+        self.field = field
+
+    def evaluate(self, _tuple, scheme, state=None):
+        """Raise an error on attempted evaluation.
+
+        DottedRef expressions are not "evaluated" in the usual sense.  Rather,
+        they are replaced with raw attribute references during compilation.
+        """
+        raise NotImplementedError()
+
+    def typeof(self, scheme, state_scheme):
+        raise NotImplementedError()  # See above comment
+
+    def __repr__(self):
+        return "{op}({re!r}, {f!r})".format(
+            op=self.opname(), re=self.table_alias, f=self.field)
+
+    def __str__(self):
+        return "{op}({re}.{f})".format(
+            op=self.opname(), re=self.table_alias, f=self.field)
+
+
 class Unbox(ZeroaryOperator):
 
     def __init__(self, table_name, field):
@@ -579,7 +613,7 @@ class Unbox(ZeroaryOperator):
         """Raise an error on attempted evaluation.
 
         Unbox expressions are not "evaluated" in the usual sense.  Rather, they
-        are replaced with raw attribute references at evaluation time.
+        are replaced with raw attribute references during compilation.
         """
         raise NotImplementedError()
 

--- a/raco/myrial/emitarg.py
+++ b/raco/myrial/emitarg.py
@@ -47,7 +47,7 @@ def resolve_unbox(sx, symbols):
         return sx.field
     else:
         assert isinstance(sx.field, int)
-        op = symbols[sx.relational_expression]
+        op = symbols[sx.table_name]
         scheme = op.scheme()
         return scheme.getName(sx.field)
 

--- a/raco/myrial/emitarg.py
+++ b/raco/myrial/emitarg.py
@@ -143,4 +143,3 @@ class FullWildcardEmitArg(EmitArg):
 
     def __repr__(self):
         return 'FullWildcardEmitArg()'
-

--- a/raco/myrial/emitarg.py
+++ b/raco/myrial/emitarg.py
@@ -124,7 +124,7 @@ class TableWildcardEmitArg(EmitArg):
         return expand_relation(self.relation_name, symbols)
 
     def __repr__(self):
-        return 'TableWildcardEmitArg(%s)' % self.relation_name
+        return 'TableWildcardEmitArg(%r)' % self.relation_name
 
 
 class FullWildcardEmitArg(EmitArg):

--- a/raco/myrial/emitarg.py
+++ b/raco/myrial/emitarg.py
@@ -95,6 +95,9 @@ class NaryEmitArg(EmitArg):
     def get_statemods(self):
         return self.statemods
 
+    def __repr__(self):
+        return 'NaryEmitArg(%r)' % self.sexprs
+
 
 def expand_relation(relation_name, symbols):
     """Expand a given relation into a list of column mappings."""
@@ -119,6 +122,9 @@ class TableWildcardEmitArg(EmitArg):
     def expand(self, symbols):
         return expand_relation(self.relation_name, symbols)
 
+    def __repr__(self):
+        return 'TableWildcardEmitArg(%s)' % self.relation_name
+
 
 class FullWildcardEmitArg(EmitArg):
     """Emit all columns from the input.
@@ -134,3 +140,7 @@ class FullWildcardEmitArg(EmitArg):
         for relation_name in symbols:
             cols.extend(expand_relation(relation_name, symbols))
         return cols
+
+    def __repr__(self):
+        return 'FullWildcardEmitArg()'
+

--- a/raco/myrial/emitarg.py
+++ b/raco/myrial/emitarg.py
@@ -1,5 +1,5 @@
 
-from raco.expression import Unbox, UnnamedAttributeRef, NamedAttributeRef
+from raco.expression import DottedRef, UnnamedAttributeRef, NamedAttributeRef
 from raco.myrial.exceptions import ColumnIndexOutOfBounds
 
 
@@ -38,7 +38,7 @@ def resolve_attribute_index(idx, symbols):
     raise ColumnIndexOutOfBounds(str(idx))
 
 
-def resolve_unbox(sx, symbols):
+def resolve_dotted_ref(sx, symbols):
     """Resolve a column name given an unbox expression.
 
     e.g. [FROM A EMIT A.some_column]
@@ -47,7 +47,7 @@ def resolve_unbox(sx, symbols):
         return sx.field
     else:
         assert isinstance(sx.field, int)
-        op = symbols[sx.table_name]
+        op = symbols[sx.table_alias]
         scheme = op.scheme()
         return scheme.getName(sx.field)
 
@@ -67,8 +67,8 @@ def get_column_name(name, sx, symbols):
         return sx.name
     elif isinstance(sx, UnnamedAttributeRef):
         return resolve_attribute_index(sx.position, symbols)
-    elif isinstance(sx, Unbox):
-        return resolve_unbox(sx, symbols)
+    elif isinstance(sx, DottedRef):
+        return resolve_dotted_ref(sx, symbols)
     else:
         return name
 
@@ -104,7 +104,7 @@ def expand_relation(relation_name, symbols):
     scheme = op.scheme()
 
     colnames = [x[0] for x in iter(scheme)]
-    return [(colname, Unbox(relation_name, colname))
+    return [(colname, DottedRef(relation_name, colname))
             for colname in colnames]
 
 

--- a/raco/myrial/emitarg.py
+++ b/raco/myrial/emitarg.py
@@ -1,6 +1,6 @@
 
 from raco.expression import DottedRef, UnnamedAttributeRef, NamedAttributeRef
-from raco.myrial.exceptions import ColumnIndexOutOfBounds
+from raco.myrial.exceptions import *
 
 
 class EmitArg(object):
@@ -101,7 +101,8 @@ class NaryEmitArg(EmitArg):
 
 def expand_relation(relation_name, symbols):
     """Expand a given relation into a list of column mappings."""
-    assert relation_name in symbols
+    if relation_name not in symbols:
+        raise NoSuchRelationException(relation_name)
 
     op = symbols[relation_name]
     scheme = op.scheme()

--- a/raco/myrial/exceptions.py
+++ b/raco/myrial/exceptions.py
@@ -154,3 +154,11 @@ class SchemaMismatchException(MyrialCompileException):
 
     def __str__(self):
         return "Incompatible input schemas for %s operation" % self.op_name
+
+
+class NoSuchRelationException(MyrialCompileException):
+    def __init__(self, relname):
+        self.relname = relname
+
+    def __str__(self):
+        return "No such relation: %s" % self.relname

--- a/raco/myrial/interpreter.py
+++ b/raco/myrial/interpreter.py
@@ -27,10 +27,6 @@ class InvalidStatementException(Exception):
     pass
 
 
-class NoSuchRelationException(Exception):
-    pass
-
-
 def get_unnamed_ref(column_ref, scheme, offset=0):
     """Convert a string or int into an attribute ref on the new table"""  # noqa
     if isinstance(column_ref, int):

--- a/raco/myrial/interpreter.py
+++ b/raco/myrial/interpreter.py
@@ -143,8 +143,18 @@ class ExpressionProcessor(object):
             if isinstance(sub_expr, raco.expression.Unbox):
                 rex = sub_expr.relational_expression
                 if rex not in from_args:
-                    unbox_op = self.evaluate(rex)
-                    from_args[rex] = unbox_op
+                    # TODO this check seems very strange.
+                    #  1) rex is a string -- look up its symbol above
+                    #  2) rex is not in that table, so it's an alias or other
+                    #     expression. Evaluate it.
+                    #  which missed 3) rex is a string but not in the table,
+                    #     it's a typo. Evaluating leads to weird error, so
+                    #     make sure it's an expression by proxy to it's a tuple
+                    if type(rex) is tuple:
+                        unbox_op = self.evaluate(rex)
+                        from_args[rex] = unbox_op
+                    else:
+                        raise NoSuchRelationException(rex)
 
     def bagcomp(self, from_clause, where_clause, emit_clause):
         """Evaluate a bag comprehension.

--- a/raco/myrial/interpreter.py
+++ b/raco/myrial/interpreter.py
@@ -153,7 +153,6 @@ class ExpressionProcessor(object):
                 if name not in from_args:
                     from_args[name] = self.__lookup_symbol(name)
 
-
     def bagcomp(self, from_clause, where_clause, emit_clause):
         """Evaluate a bag comprehension.
 

--- a/raco/myrial/interpreter.py
+++ b/raco/myrial/interpreter.py
@@ -77,6 +77,9 @@ class ExpressionProcessor(object):
         return method(*expr[1:])
 
     def __lookup_symbol(self, _id):
+        if _id not in self.symbols:
+            raise NoSuchRelationException(_id)
+
         self.uses_set.add(_id)
         return copy.deepcopy(self.symbols[_id])
 

--- a/raco/myrial/multiway.py
+++ b/raco/myrial/multiway.py
@@ -42,7 +42,7 @@ def rewrite_refs(sexpr, from_args, base_offsets):
         if not isinstance(sexpr, expression.Unbox):
             return sexpr
         else:
-            op = from_args[sexpr.relational_expression]
+            op = from_args[sexpr.table_name]
             scheme = op.scheme()
 
             debug_info = None
@@ -57,7 +57,7 @@ def rewrite_refs(sexpr, from_args, base_offsets):
                 offset = scheme.getPosition(sexpr.field)
                 debug_info = sexpr.field
 
-            offset += base_offsets[sexpr.relational_expression]
+            offset += base_offsets[sexpr.table_name]
             return expression.UnnamedAttributeRef(offset, debug_info)
 
     def recursive_eval(sexpr):

--- a/raco/myrial/multiway.py
+++ b/raco/myrial/multiway.py
@@ -8,7 +8,7 @@ from raco.myrial.exceptions import ColumnIndexOutOfBounds
 
 
 def rewrite_statemods(statemods, from_args, base_offsets):
-    """Convert Unbox expressions contained inside statemod variables.
+    """Convert DottedRef expressions contained inside statemod variables.
 
     :param statemods: A list of StateVar instances
     :param from_args: A map from relation name to Operator
@@ -21,7 +21,7 @@ def rewrite_statemods(statemods, from_args, base_offsets):
 
 
 def rewrite_refs(sexpr, from_args, base_offsets):
-    """Convert all Unbox expressions into raw indexes."""
+    """Convert all DottedRef expressions into raw indexes."""
 
     def rewrite_node(sexpr):
         # Push unboxing into the state variables of distributed aggregates
@@ -39,10 +39,10 @@ def rewrite_refs(sexpr, from_args, base_offsets):
                             ds.get_finalizer()))
                 return sexpr
 
-        if not isinstance(sexpr, expression.Unbox):
+        if not isinstance(sexpr, expression.DottedRef):
             return sexpr
         else:
-            op = from_args[sexpr.table_name]
+            op = from_args[sexpr.table_alias]
             scheme = op.scheme()
 
             debug_info = None
@@ -57,7 +57,7 @@ def rewrite_refs(sexpr, from_args, base_offsets):
                 offset = scheme.getPosition(sexpr.field)
                 debug_info = sexpr.field
 
-            offset += base_offsets[sexpr.table_name]
+            offset += base_offsets[sexpr.table_alias]
             return expression.UnnamedAttributeRef(offset, debug_info)
 
     def recursive_eval(sexpr):

--- a/raco/myrial/multiway.py
+++ b/raco/myrial/multiway.py
@@ -3,8 +3,7 @@
 from raco import algebra
 from raco import expression
 from raco.expression.statevar import *
-
-from raco.myrial.exceptions import ColumnIndexOutOfBounds
+from raco.myrial.exceptions import *
 
 
 def rewrite_statemods(statemods, from_args, base_offsets):
@@ -41,6 +40,8 @@ def rewrite_refs(sexpr, from_args, base_offsets):
 
         if not isinstance(sexpr, expression.DottedRef):
             return sexpr
+        elif sexpr.table_alias not in from_args:
+            raise NoSuchRelationException(sexpr.table_alias)
         else:
             op = from_args[sexpr.table_alias]
             scheme = op.scheme()

--- a/raco/myrial/parser.py
+++ b/raco/myrial/parser.py
@@ -816,14 +816,9 @@ class Parser(object):
         p[0] = sexpr.UnnamedAttributeRef(p[2])
 
     @staticmethod
-    def p_sexpr_id_dot_id(p):
-        'sexpr : unreserved_id DOT unreserved_id'
+    def p_sexpr_id_dot_ref(p):
+        'sexpr : unreserved_id DOT column_ref'
         p[0] = sexpr.Unbox(p[1], p[3])
-
-    @staticmethod
-    def p_sexpr_id_dot_pos(p):
-        'sexpr : unreserved_id DOT DOLLAR INTEGER_LITERAL'
-        p[0] = sexpr.Unbox(p[1], p[4])
 
     @staticmethod
     def p_sexpr_group(p):

--- a/raco/myrial/parser.py
+++ b/raco/myrial/parser.py
@@ -818,7 +818,7 @@ class Parser(object):
     @staticmethod
     def p_sexpr_id_dot_ref(p):
         'sexpr : unreserved_id DOT column_ref'
-        p[0] = sexpr.Unbox(p[1], p[3])
+        p[0] = sexpr.DottedRef(p[1], p[3])
 
     @staticmethod
     def p_sexpr_group(p):

--- a/raco/myrial/parser.py
+++ b/raco/myrial/parser.py
@@ -1001,7 +1001,7 @@ class Parser(object):
 
     @staticmethod
     def p_sexpr_unbox(p):
-        'sexpr : TIMES expression optional_column_ref'
+        'sexpr : TIMES unreserved_id optional_column_ref'
         p[0] = sexpr.Unbox(p[2], p[3])
 
     @staticmethod

--- a/raco/myrial/query_tests.py
+++ b/raco/myrial/query_tests.py
@@ -1107,6 +1107,17 @@ class TestQueryFunctions(myrial_test.MyrialTestCase, FakeData):
         with self.assertRaises(NoSuchRelationException):
             self.check_result(query, collections.Counter())
 
+    def test_bad_relation_name(self):
+        query = """
+        y = empty(a:int);
+        z = [from s y      -- bug: s does not exist
+             emit y.a];
+        store(z, debug);
+        """
+
+        with self.assertRaises(NoSuchRelationException):
+            self.check_result(query, collections.Counter())
+
     def test_bad_alias(self):
         query = """
         y = empty(a:int);
@@ -1121,7 +1132,7 @@ class TestQueryFunctions(myrial_test.MyrialTestCase, FakeData):
     def test_bad_alias_wildcard(self):
         query = """
         y = empty(a:int);
-        z = [from y s -- bug: errant s
+        z = [from y s      -- bug: errant s
              emit y.*];
         store(z, debug);
         """

--- a/raco/myrial/query_tests.py
+++ b/raco/myrial/query_tests.py
@@ -1107,6 +1107,17 @@ class TestQueryFunctions(myrial_test.MyrialTestCase, FakeData):
         with self.assertRaises(raco.myrial.interpreter.NoSuchRelationException):  # noqa
             self.check_result(query, collections.Counter())
 
+    def test_bad_alias(self):
+        query = """
+        y = empty(a:int);
+        z = [from y s      -- bug: extra s
+             emit y.a];
+        store(z, debug);
+        """
+
+        with self.assertRaises(raco.myrial.interpreter.NoSuchRelationException):  # noqa
+            self.check_result(query, collections.Counter())
+
     def test_scan_error(self):
         query = """
         out = [FROM SCAN(%s) AS X EMIT id, !!!FROG(val)];

--- a/raco/myrial/query_tests.py
+++ b/raco/myrial/query_tests.py
@@ -327,6 +327,19 @@ class TestQueryFunctions(myrial_test.MyrialTestCase, FakeData):
 
         self.check_result(query, self.join_expected)
 
+    def test_explicit_join_twocols(self):
+        query = """
+        query = [1 as dept_id, 25000 as salary];
+        emp = SCAN({emp});
+        out = JOIN(query, (dept_id, salary), emp, (dept_id, salary));
+        out2 = [FROM out EMIT name];
+        STORE(out2, OUTPUT);
+        """.format(emp=self.emp_key)
+
+        expected = collections.Counter([('Victor Almeida',),
+                                        ('Magdalena Balazinska',)])
+        self.check_result(query, expected)
+
     def test_bagcomp_join_via_names(self):
         query = """
         out = [FROM SCAN(%s) E, SCAN(%s) AS D WHERE E.dept_id == D.id
@@ -346,6 +359,19 @@ class TestQueryFunctions(myrial_test.MyrialTestCase, FakeData):
         """ % (self.emp_key, self.dept_key)
 
         self.check_result(query, self.join_expected)
+
+    def test_two_column_join(self):
+        query = """
+        D = [1 as dept_id, 25000 as salary];
+        out = [FROM D, SCAN({emp}) E
+               WHERE E.dept_id == D.dept_id AND E.salary == D.salary
+               EMIT E.name AS emp_name];
+        STORE(out, OUTPUT);
+        """.format(emp=self.emp_key)
+
+        expected = collections.Counter([('Victor Almeida',),
+                                        ('Magdalena Balazinska',)])
+        self.check_result(query, expected)
 
     def test_join_with_select(self):
         query = """

--- a/raco/myrial/query_tests.py
+++ b/raco/myrial/query_tests.py
@@ -667,11 +667,11 @@ class TestQueryFunctions(myrial_test.MyrialTestCase, FakeData):
              x[0] > len(self.dept_table)])
         self.check_result(query, expected)
 
-    def test_unbox_inline_table_literal(self):
+    def test_inline_table_literal(self):
         query = """
         emp = SCAN(%s);
         dept = SCAN(%s);
-        out = [FROM emp WHERE id > *[1,2,3].$2 EMIT emp.id];
+        out = [FROM emp, [1,2,3] as tl WHERE id > tl.$2 EMIT emp.id];
         STORE(out, OUTPUT);
         """ % (self.emp_key, self.dept_key)
 

--- a/raco/myrial/query_tests.py
+++ b/raco/myrial/query_tests.py
@@ -1118,6 +1118,17 @@ class TestQueryFunctions(myrial_test.MyrialTestCase, FakeData):
         with self.assertRaises(NoSuchRelationException):
             self.check_result(query, collections.Counter())
 
+    def test_bad_alias_wildcard(self):
+        query = """
+        y = empty(a:int);
+        z = [from y s -- bug: errant s
+             emit y.*];
+        store(z, debug);
+        """
+
+        with self.assertRaises(NoSuchRelationException):
+            self.check_result(query, collections.Counter())
+
     def test_scan_error(self):
         query = """
         out = [FROM SCAN(%s) AS X EMIT id, !!!FROG(val)];

--- a/raco/myrial/query_tests.py
+++ b/raco/myrial/query_tests.py
@@ -1144,7 +1144,7 @@ class TestQueryFunctions(myrial_test.MyrialTestCase, FakeData):
         STORE(out, OUTPUT);
         """
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(NoSuchRelationException):
             self.check_result(query, collections.Counter())
 
     def test_relation_scope_error2(self):
@@ -1154,7 +1154,7 @@ class TestQueryFunctions(myrial_test.MyrialTestCase, FakeData):
         STORE(out, OUTPUT);
         """
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(NoSuchRelationException):
             self.check_result(query, collections.Counter())
 
     def test_parse_error(self):

--- a/raco/myrial/query_tests.py
+++ b/raco/myrial/query_tests.py
@@ -1104,7 +1104,7 @@ class TestQueryFunctions(myrial_test.MyrialTestCase, FakeData):
         STORE(out, OUTPUT);
         """
 
-        with self.assertRaises(raco.myrial.interpreter.NoSuchRelationException):  # noqa
+        with self.assertRaises(NoSuchRelationException):
             self.check_result(query, collections.Counter())
 
     def test_bad_alias(self):
@@ -1115,7 +1115,7 @@ class TestQueryFunctions(myrial_test.MyrialTestCase, FakeData):
         store(z, debug);
         """
 
-        with self.assertRaises(raco.myrial.interpreter.NoSuchRelationException):  # noqa
+        with self.assertRaises(NoSuchRelationException):
             self.check_result(query, collections.Counter())
 
     def test_scan_error(self):

--- a/raco/myrial/query_tests.py
+++ b/raco/myrial/query_tests.py
@@ -658,7 +658,7 @@ class TestQueryFunctions(myrial_test.MyrialTestCase, FakeData):
         query = """
         emp = SCAN(%s);
         dept = SCAN(%s);
-        out = [FROM emp WHERE id > *COUNTALL(dept) EMIT emp.id];
+        out = [FROM emp, COUNTALL(dept) as size WHERE id > *size EMIT emp.id];
         STORE(out, OUTPUT);
         """ % (self.emp_key, self.dept_key)
 


### PR DESCRIPTION
This PR simplifies the implementation of unboxing in Myrial.  More controversially, it also simplifies the language-level design of this feature.

At the language level, we now disallow non-trivial unbox expressions.  That is, you can only unbox a table name, not some arbitrary expression.  Previously, you could say this:

```python
 out = [FROM emp WHERE id > *COUNTALL(dept) EMIT emp.id];
```

Now, you must use this:

```python
out = [FROM emp, COUNTALL(dept) as size WHERE id > *size EMIT emp.id];
```

This simplifies the overall design, since unbox expressions are now just simple column references.

I clarified the implementation by distinguishing DottedRef expressions (e.g., MyTable.MyColumn) from Unbox expressions ($SomeTable.MyColumn).  I also added various comments and code cleanup.

Fixes #283 
Subsumes #382 
