### PR TITLE
Unicode programs

### DIFF
--- a/raco/clangtestdb.py
+++ b/raco/clangtestdb.py
@@ -23,7 +23,7 @@ class ClangTestDatabase(Catalog):
 
     def ingest(self, rel_key, contents, scheme):
         '''Directly load raw data into the database'''
-        if isinstance(rel_key, str):
+        if isinstance(rel_key, basestring):
             rel_key = relation_key.RelationKey.from_string(rel_key)
         assert isinstance(rel_key, relation_key.RelationKey)
 
@@ -35,7 +35,7 @@ class ClangTestDatabase(Catalog):
         self.tables[rel_key] = scheme
 
     def get_scheme(self, rel_key):
-        if isinstance(rel_key, str):
+        if isinstance(rel_key, basestring):
             rel_key = relation_key.RelationKey.from_string(rel_key)
 
         assert isinstance(rel_key, relation_key.RelationKey)

--- a/raco/expression/expression.py
+++ b/raco/expression/expression.py
@@ -571,7 +571,7 @@ class DottedRef(ZeroaryOperator):
         :param table_alias: The name of a table alias (a string).
         :param field: The column name/index within the relation.
         """
-        assert isinstance(table_alias, str)
+        assert isinstance(table_alias, basestring)
         self.table_alias = table_alias
         self.field = field
 

--- a/raco/fakedb.py
+++ b/raco/fakedb.py
@@ -62,13 +62,13 @@ class FakeDatabase(Catalog):
 
     def ingest(self, rel_key, contents, scheme):
         """Directly load raw data into the database"""
-        if isinstance(rel_key, str):
+        if isinstance(rel_key, basestring):
             rel_key = relation_key.RelationKey.from_string(rel_key)
         assert isinstance(rel_key, relation_key.RelationKey)
         self.tables.add_table(rel_key, scheme, contents.elements())
 
     def get_scheme(self, rel_key):
-        if isinstance(rel_key, str):
+        if isinstance(rel_key, basestring):
             rel_key = relation_key.RelationKey.from_string(rel_key)
 
         assert isinstance(rel_key, relation_key.RelationKey)
@@ -82,7 +82,7 @@ class FakeDatabase(Catalog):
         :type rel_key: relation_key.RelationKey
         :returns: A collections.Counter instance containing tuples.
         """
-        if isinstance(rel_key, str):
+        if isinstance(rel_key, basestring):
             rel_key = relation_key.RelationKey.from_string(rel_key)
         assert isinstance(rel_key, relation_key.RelationKey)
         return self.tables.get_table(rel_key)

--- a/raco/myrial/interpreter.py
+++ b/raco/myrial/interpreter.py
@@ -148,7 +148,7 @@ class ExpressionProcessor(object):
         for sub_expr in sexpr.walk():
             if isinstance(sub_expr, raco.expression.Unbox):
                 name = sub_expr.table_name
-                assert isinstance(name, str)
+                assert isinstance(name, basestring)
                 if name not in from_args:
                     from_args[name] = self.__lookup_symbol(name)
 
@@ -174,7 +174,7 @@ class ExpressionProcessor(object):
         from_args = collections.OrderedDict()
 
         for _id, expr in from_clause:
-            assert isinstance(_id, str)
+            assert isinstance(_id, basestring)
             if expr:
                 from_args[_id] = self.evaluate(expr)
             else:

--- a/raco/myrial/query_tests.py
+++ b/raco/myrial/query_tests.py
@@ -316,6 +316,17 @@ class TestQueryFunctions(myrial_test.MyrialTestCase, FakeData):
          ('Dan Suciu', 'engineering'),
          ('Magdalena Balazinska', 'accounting')])
 
+    def test_explicit_join_unicode(self):
+        query = u"""
+        emp = SCAN(%s);
+        dept = SCAN(%s);
+        out = JOIN(emp, dept_id, dept, id);
+        out2 = [FROM out EMIT $2 AS emp_name, $5 AS dept_name];
+        STORE(out2, OUTPUT);
+        """ % (self.emp_key, self.dept_key)
+
+        self.check_result(query, self.join_expected)
+
     def test_explicit_join(self):
         query = """
         emp = SCAN(%s);


### PR DESCRIPTION
The myria-web tests identified an issue with the assumption that strings are `str` rather than `unicode`. (https://travis-ci.org/uwescience/myria-web/builds/46695474).

Add a test that causes this bug, then fix `str` to `basestring` for `isinstance` checks throughout.