### PR TITLE
Myria insert split

### DIFF
--- a/raco/algebra.py
+++ b/raco/algebra.py
@@ -1087,6 +1087,18 @@ class Broadcast(UnaryOperator):
         return self.opname()
 
 
+class Split(UnaryOperator):
+    """An in-memory pipeline between two operators. Typically used in
+    multi-threaded systems for IPC between threads executing different
+    operator subtrees."""
+
+    def num_tuples(self):
+        return self.input.num_tuples()
+
+    def shortStr(self):
+        return self.opname()
+
+
 class PartitionBy(UnaryOperator):
 
     """Send input to a server indicated by a hash of specified columns."""

--- a/raco/fakedb.py
+++ b/raco/fakedb.py
@@ -367,6 +367,12 @@ class FakeDatabase(Catalog):
     def myriahypershuffleproducer(self, op):
         return self.evaluate(op.input)
 
+    def myriasplitconsumer(self, op):
+        return self.evaluate(op.input)
+
+    def myriasplitproducer(self, op):
+        return self.evaluate(op.input)
+
     def myriastore(self, op):
         return self.store(op)
 

--- a/raco/language/myrialang.py
+++ b/raco/language/myrialang.py
@@ -1294,7 +1294,8 @@ class InsertSplit(rules.Rule):
     """Inserts an algebra.Split operator in every fragment that has multiple
     heavy-weight operators."""
     heavy_ops = (algebra.Store, algebra.StoreTemp,
-                 algebra.CrossProduct, algebra.Join, algebra.GroupBy)
+                 algebra.CrossProduct, algebra.Join, algebra.NaryJoin,
+                 algebra.GroupBy, algebra.OrderBy)
 
     def insert_split_before_heavy(self, op):
         """Walk the tree starting from op and insert a split when we

--- a/raco/language/myrialang.py
+++ b/raco/language/myrialang.py
@@ -1577,6 +1577,10 @@ def compile_fragment(frag_root):
 
 
 def compile_plan(plan_op):
+    """Given a root operator in the Myria backend (MyriaX?) physical algebra,
+    produce the dictionary encoding of the physical plan, in other words, a
+    nested collection of Java QueryPlan operators."""
+
     subplan_ops = (algebra.Parallel, algebra.Sequence, algebra.DoWhile)
     if not isinstance(plan_op, subplan_ops):
         plan_op = algebra.Parallel([plan_op])


### PR DESCRIPTION
@jingjingwang @stechu I think we've talked about these changes.

When a fragment contains multiple heavyweight operators (e.g., join followed by join), we can insert LocalMultiwayProducer to split them into two threads on the same machine. This PR implements this change.