### PR TITLE
myria: hash after singleton

### DIFF
--- a/raco/language/myrialang.py
+++ b/raco/language/myrialang.py
@@ -1127,6 +1127,17 @@ class BroadcastBeforeCross(rules.Rule):
         return expr
 
 
+class ShuffleAfterSingleton(rules.Rule):
+    def fire(self, expr):
+        if isinstance(expr, MyriaSingleton):
+            return expr
+
+        if isinstance(expr, algebra.SingletonRelation):
+            return algebra.Shuffle(MyriaSingleton(), [UnnamedAttributeRef(0)])
+
+        return expr
+
+
 class DecomposeGroupBy(rules.Rule):
     """Convert a logical group by into a two-phase group by.
 
@@ -1416,7 +1427,8 @@ class GetCardinalities(rules.Rule):
 left_deep_tree_shuffle_logic = [
     ShuffleBeforeSetop(),
     ShuffleBeforeJoin(),
-    BroadcastBeforeCross()
+    BroadcastBeforeCross(),
+    ShuffleAfterSingleton()
 ]
 
 # 7. distributed groupby


### PR DESCRIPTION
We've had several Myria bugs resulting from the way
that Singleton operators are handled. The easiest way
to handle it, for now, seems to be to just always hash
them out. (Singletons do have a single, non-null column
in MyriaX semantics).

Fix uwescience/myria#704