### PR TITLE
Code/test changes to enable modulo operator.

### DIFF
--- a/c_test_environment/platform_tests.py
+++ b/c_test_environment/platform_tests.py
@@ -332,6 +332,10 @@ class MyriaLPlatformTests(object):
         STORE(out, OUTPUT);
         """, "apply")
 
+    def test_idivide(self):
+        q = self.myrial_from_sql(['T2'], "idivide").replace("/", "//")
+        self.check(q, "idivide")
+
     def test_apply_and_self_join(self):
         q = self.myrial_from_sql(['T3'], "apply_and_self_join")
         self.check(q, "apply_and_self_join")

--- a/c_test_environment/testqueries/idivide.sql
+++ b/c_test_environment/testqueries/idivide.sql
@@ -1,0 +1,1 @@
+select a/b from T2 where b!=0;

--- a/raco/expression/expression.py
+++ b/raco/expression/expression.py
@@ -513,6 +513,19 @@ class IDIVIDE(BinaryOperator):
         return types.LONG_TYPE
 
 
+class MOD(BinaryOperator):
+    literals = ["%"]
+
+    def evaluate(self, _tuple, scheme, state=None):
+        return int(self.left.evaluate(_tuple, scheme, state) %
+                   self.right.evaluate(_tuple, scheme, state))
+
+    def typeof(self, scheme, state_scheme):
+        check_is_numeric(self.left.typeof(scheme, state_scheme))
+        check_is_numeric(self.right.typeof(scheme, state_scheme))
+        return types.LONG_TYPE
+
+
 class TIMES(BinaryOperator):
     literals = ["*"]
 

--- a/raco/expression/visitor.py
+++ b/raco/expression/visitor.py
@@ -101,6 +101,10 @@ class ExpressionVisitor(object):
         return
 
     @abstractmethod
+    def visit_MOD(self, binaryExpr):
+        return
+
+    @abstractmethod
     def visit_TIMES(self, binaryExpr):
         return
 
@@ -207,6 +211,9 @@ class SimpleExpressionVisitor(ExpressionVisitor):
         self.visit_binary(binaryExpr)
 
     def visit_IDIVIDE(self, binaryExpr):
+        self.visit_binary(binaryExpr)
+
+    def visit_MOD(self, binaryExpr):
         self.visit_binary(binaryExpr)
 
     def visit_TIMES(self, binaryExpr):

--- a/raco/language/__init__.py
+++ b/raco/language/__init__.py
@@ -157,7 +157,11 @@ class CompileExpressionVisitor(ExpressionVisitor):
 
     def visit_IDIVIDE(self, binaryexpr):
         left, right = self.__visit_BinaryOperator__(binaryexpr)
-        self.stack.append(self.combine([left, right], operator="/"))
+        self.stack.append(self.combine([left, right], operator="//"))
+
+    def visit_MOD(self, binaryexpr):
+        left, right = self.__visit_BinaryOperator__(binaryexpr)
+        self.stack.append(self.combine([left, right], operator="%"))
 
     def visit_TIMES(self, binaryexpr):
         left, right = self.__visit_BinaryOperator__(binaryexpr)

--- a/raco/language/clangcommon.py
+++ b/raco/language/clangcommon.py
@@ -106,6 +106,11 @@ class CBaseLanguage(Language):
 
     @classmethod
     def expression_combine(cls, args, operator="&&"):
+        # special case for integer divide. C doesn't have this syntax
+        # Rely on automatic conversion from float to int
+        if operator == "//":
+            operator = "/"
+
         opstr = " %s " % operator
         codes, decls, inits = cls._extract_code_decl_init(args)
         conjunc = opstr.join(["(%s)" % c for c in codes])

--- a/raco/myrial/parser.py
+++ b/raco/myrial/parser.py
@@ -37,6 +37,7 @@ binops = {
     '-': sexpr.MINUS,
     '/': sexpr.DIVIDE,
     '//': sexpr.IDIVIDE,
+    '%': sexpr.MOD,
     '*': sexpr.TIMES,
     '>': sexpr.GT,
     '<': sexpr.LT,
@@ -153,7 +154,7 @@ class Parser(object):
             ('right', 'NOT'),
             ('left', 'EQ', 'EQUALS', 'NE', 'GT', 'LT', 'LE', 'GE'),
             ('left', 'PLUS', 'MINUS'),
-            ('left', 'TIMES', 'DIVIDE', 'IDIVIDE'),
+            ('left', 'TIMES', 'DIVIDE', 'IDIVIDE', 'MOD'),
             ('right', 'UMINUS'),    # Unary minus
         )
 
@@ -852,6 +853,7 @@ class Parser(object):
                    | sexpr TIMES sexpr
                    | sexpr DIVIDE sexpr
                    | sexpr IDIVIDE sexpr
+                   | sexpr MOD sexpr
                    | sexpr GT sexpr
                    | sexpr LT sexpr
                    | sexpr GE sexpr

--- a/raco/myrial/scanner.py
+++ b/raco/myrial/scanner.py
@@ -26,9 +26,9 @@ reserved = (keywords + types + comprehension_keywords
 # Token types; required by ply to have this variable name
 
 tokens = ['LPAREN', 'RPAREN', 'LBRACKET', 'RBRACKET', 'DOT', 'PLUS', 'MINUS',
-          'TIMES', 'DIVIDE', 'IDIVIDE', 'LT', 'GT', 'GE', 'GE2', 'LE', 'LE2',
-          'EQ', 'NE', 'NE2', 'NE3', 'COMMA', 'SEMI', 'EQUALS', 'COLON',
-          'DOLLAR', 'ID',
+          'TIMES', 'DIVIDE', 'IDIVIDE', 'MOD', 'LT', 'GT', 'GE', 'GE2',
+          'LE', 'LE2', 'EQ', 'NE', 'NE2', 'NE3', 'COMMA', 'SEMI', 'EQUALS',
+          'COLON', 'DOLLAR', 'ID',
           'STRING_LITERAL', 'INTEGER_LITERAL', 'FLOAT_LITERAL',
           'LBRACE', 'RBRACE'] + reserved
 
@@ -45,6 +45,7 @@ t_MINUS = r'-'
 t_TIMES = r'\*'
 t_DIVIDE = r'/'
 t_IDIVIDE = r'//'
+t_MOD = r'%'
 
 t_LT = r'<'
 t_GT = r'>'

--- a/raco/myrial/type_tests.py
+++ b/raco/myrial/type_tests.py
@@ -126,6 +126,22 @@ class TypeTests(MyrialTestCase):
         schema = Scheme([('y', types.LONG_TYPE)])
         self.check_scheme(query, schema)
 
+    def test_mod(self):
+        query = """
+        X = [FROM SCAN(public:adhoc:mytable) AS X EMIT clong % cint AS y];
+        STORE(X, OUTPUT);
+        """
+        schema = Scheme([('y', types.LONG_TYPE)])
+        self.check_scheme(query, schema)
+
+    def test_invalid_mod(self):
+        query = """
+        X = [FROM SCAN(public:adhoc:mytable) AS X EMIT cdate % cint];
+        STORE(X, OUTPUT);
+        """
+        with self.assertRaises(TypeSafetyViolation):
+            self.check_scheme(query, None)
+
     def test_neg(self):
         query = """
         X = [FROM SCAN(public:adhoc:mytable) AS X EMIT -cstring];

--- a/raco/tests.py
+++ b/raco/tests.py
@@ -95,7 +95,9 @@ class ExpressionTest(unittest.TestCase):
                 pass
 
             def visit_MOD(self, binaryExpr):
-                pass
+                right = self.stack.pop()
+                left = self.stack.pop()
+                self.stack.append(left % right)
 
             def visit_MINUS(self, binaryExpr):
                 pass
@@ -138,6 +140,11 @@ class ExpressionTest(unittest.TestCase):
                    e.NOT(e.NEQ(e.NumericLiteral(4), e.NumericLiteral(4))))
         ex.accept(v)
         self.assertEqual(v.stack.pop(), True)
+
+        v = EvalVisitor()
+        ex = e.MOD(e.NumericLiteral(7), e.NumericLiteral(4))
+        ex.accept(v)
+        self.assertEqual(v.stack.pop(), 3)
 
         v = EvalVisitor()
         ex = e.NumericLiteral(0xC0FFEE)

--- a/raco/tests.py
+++ b/raco/tests.py
@@ -94,6 +94,9 @@ class ExpressionTest(unittest.TestCase):
             def visit_IDIVIDE(self, binaryExpr):
                 pass
 
+            def visit_MOD(self, binaryExpr):
+                pass
+
             def visit_MINUS(self, binaryExpr):
                 pass
 


### PR DESCRIPTION
Not sure whether I did the right thing at https://github.com/uwescience/raco/compare/mod_op#diff-e9797c7b402b3bc30b2713606bcf6097R160. I thought the Python syntax for the intdiv operator was also part of MyriaL syntax, so the visitor should be using the Python intdiv syntax, not the general div symbol.

I have been unable to get nosetests working on my dev machine despite everything seeming to check out (the version of nose that nosetests expects is installed, I can import it in a python shell and check the version, etc.). I'll need some help to fix this, at least until I get my new laptop.