### PR TITLE
Fix boolean type check

### DIFF
--- a/raco/expression/boolean.py
+++ b/raco/expression/boolean.py
@@ -25,7 +25,7 @@ class BinaryBooleanOperator(BooleanExpression, BinaryOperator):
     def typeof(self, scheme, state_scheme):
         lt = self.left.typeof(scheme, state_scheme)
         check_type(lt, raco.types.BOOLEAN_TYPE)
-        rt = self.left.typeof(scheme, state_scheme)
+        rt = self.right.typeof(scheme, state_scheme)
         check_type(rt, raco.types.BOOLEAN_TYPE)
         return raco.types.BOOLEAN_TYPE
 

--- a/raco/myrial/type_tests.py
+++ b/raco/myrial/type_tests.py
@@ -70,9 +70,25 @@ class TypeTests(MyrialTestCase):
         with self.assertRaises(TypeSafetyViolation):
             self.check_scheme(query, None)
 
-    def test_invalid_or(self):
+    def test_invalid_or_both_bad(self):
         query = """
         X = [FROM SCAN(public:adhoc:mytable) AS X EMIT cfloat OR cdate];
+        STORE(X, OUTPUT);
+        """
+        with self.assertRaises(TypeSafetyViolation):
+            self.check_scheme(query, None)
+
+    def test_invalid_or_right_bad(self):
+        query = """
+        X = [FROM SCAN(public:adhoc:mytable) AS X EMIT cbool OR cdate];
+        STORE(X, OUTPUT);
+        """
+        with self.assertRaises(TypeSafetyViolation):
+            self.check_scheme(query, None)
+
+    def test_invalid_or_left_bad(self):
+        query = """
+        X = [FROM SCAN(public:adhoc:mytable) AS X EMIT cfloat OR cbool];
         STORE(X, OUTPUT);
         """
         with self.assertRaises(TypeSafetyViolation):


### PR DESCRIPTION
Because of a bug in the type checking, we could accidentally traverse a binary tree in
exponential time instead of linear. The bug was checking the type of the same side
twice instead of checking both sides.

Add a test and fix the bug.