### PR TITLE
myrialang: add limit operator

### DIFF
--- a/raco/fakedb.py
+++ b/raco/fakedb.py
@@ -360,6 +360,9 @@ class FakeDatabase(Catalog):
     def myriascantemp(self, op):
         return self.scantemp(op)
 
+    def myrialimit(self, op):
+        return self.limit(op)
+
     def myriasymmetrichashjoin(self, op):
         return self.projectingjoin(op)
 

--- a/raco/myrial/query_tests.py
+++ b/raco/myrial/query_tests.py
@@ -602,7 +602,7 @@ class TestQueryFunctions(myrial_test.MyrialTestCase, FakeData):
         STORE(out, OUTPUT);
         """ % self.emp_key
 
-        result = self.execute_query(query, skip_json=True)
+        result = self.execute_query(query)
         self.assertEquals(len(result), 3)
 
     def test_sql_limit(self):
@@ -611,7 +611,7 @@ class TestQueryFunctions(myrial_test.MyrialTestCase, FakeData):
         STORE(out, OUTPUT);
         """ % self.emp_key
 
-        result = self.execute_query(query, skip_json=True)
+        result = self.execute_query(query)
         self.assertEquals(len(result), 3)
 
     def test_table_literal_boolean(self):


### PR DESCRIPTION
and make sure it is tested

@domoritz you mention this most frequently, so I'm assigning it to you :p

Note that such programs are not optimized very well, but `limit` is now implemented. See also [the terrible MyriaX implementation of limit](https://github.com/uwescience/myria/pull/649) attributable to push-based networking.