### PR TITLE
Natively support strings in Clang

### DIFF
--- a/c_test_environment/generate_test_relations.py
+++ b/c_test_environment/generate_test_relations.py
@@ -1,4 +1,5 @@
 import random
+import string
 import os
 from subprocess import check_call
 
@@ -36,6 +37,28 @@ def generate_random_double(basename, fields, tuples, datarange):
             for j in range(1, fields):
                 dat = random.uniform(0, datarange)
                 f.write(str(dat))
+                if j < (fields - 1):
+                    f.write(' ')
+            f.write("\n")
+
+
+def generate_strings(basename, fields, tuples, datarange):
+    """
+     First attribute is integer and the rest are strings
+    """
+    random.seed(1)
+    fn = get_name(basename, fields)
+    with open(fn, 'w') as f:
+        print "generating %s" % (os.path.abspath(fn))
+        for i in range(0, tuples):
+            f.write(str(random.randint(0, datarange)))
+            if 0 < (fields - 1):
+                f.write(' ')
+            for j in range(1, fields):
+                strmax = 24
+                strlength = random.randint(0, strmax)
+                s = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(strlength))
+                f.write(s)
                 if j < (fields - 1):
                     f.write(' ')
             f.write("\n")
@@ -84,7 +107,8 @@ def gen_files():
                                   ('S', generate_random_int, 3),
                                   ('T', generate_random_int, 3),
                                   ('D', generate_random_double, 1),
-                                  ('I', generate_last_sequential, 3)]:
+                                  ('I', generate_last_sequential, 3),
+                                  ('C', generate_strings, 1)]:
         for nf in [1, 2, 3]:
             yield (n, genfunc, intfields, nf)
 

--- a/c_test_environment/generate_test_relations.py
+++ b/c_test_environment/generate_test_relations.py
@@ -56,7 +56,7 @@ def generate_strings(basename, fields, tuples, datarange):
                 f.write(' ')
             for j in range(1, fields):
                 strmax = 24
-                strlength = random.randint(0, strmax)
+                strlength = random.randint(1, strmax)
                 s = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(strlength))
                 f.write(s)
                 if j < (fields - 1):

--- a/c_test_environment/platform_tests.py
+++ b/c_test_environment/platform_tests.py
@@ -476,6 +476,14 @@ class MyriaLPlatformTests(object):
         q = self.myrial_from_sql(["C3"], "select_string")
         self.check(q, "select_string")
 
+    def test_join_string_val(self):
+        q = self.myrial_from_sql(["C2", "T2"], "join_string_val")
+        self.check(q, "join_string_val")
+
+    def test_join_string_key(self):
+        q = self.myrial_from_sql(["C3", "C3"], "join_string_key")
+        self.check(q, "join_string_key")
+
     def test_aggregate_double(self):
         self.check_sub_tables("""
         D2 = SCAN(%(D2)s);

--- a/c_test_environment/platform_tests.py
+++ b/c_test_environment/platform_tests.py
@@ -484,6 +484,13 @@ class MyriaLPlatformTests(object):
         q = self.myrial_from_sql(["C3", "C3"], "join_string_key")
         self.check(q, "join_string_key")
 
+    def test_groupby_string_key(self):
+        self.check_sub_tables("""
+        C2 = SCAN(%(C2)s);
+        P = [FROM C2 EMIT SUM($0), $1];
+        STORE(P, OUTPUT);
+        """, "groupby_string_key")
+
     def test_aggregate_double(self):
         self.check_sub_tables("""
         D2 = SCAN(%(D2)s);

--- a/c_test_environment/platform_tests.py
+++ b/c_test_environment/platform_tests.py
@@ -491,6 +491,13 @@ class MyriaLPlatformTests(object):
         STORE(P, OUTPUT);
         """, "groupby_string_key")
 
+    def test_groupby_string_multi_key(self):
+        self.check_sub_tables("""
+        C3 = SCAN(%(C3)s);
+        P = [FROM C3 EMIT SUM($0), $1, $2];
+        STORE(P, OUTPUT);
+        """, "groupby_string_multi_key")
+
     def test_aggregate_double(self):
         self.check_sub_tables("""
         D2 = SCAN(%(D2)s);

--- a/c_test_environment/platform_tests.py
+++ b/c_test_environment/platform_tests.py
@@ -151,7 +151,7 @@ class MyriaLPlatformTestHarness(myrial_test.MyrialTestCase):
         super(MyriaLPlatformTestHarness, self).setUp()
 
         self.tables = {}
-        for name in ['R', 'S', 'T', 'I', 'D']:
+        for name in ['R', 'S', 'T', 'I', 'D', 'C']:
             for width in [1, 2, 3]:
                 tablename = "%s%d" % (name, width)
                 fullname = "public:adhoc:%s" % tablename
@@ -159,6 +159,8 @@ class MyriaLPlatformTestHarness(myrial_test.MyrialTestCase):
 
                 if name == 'D':
                     rest_type = types.DOUBLE_TYPE
+                elif name == 'C':
+                    rest_type = types.STRING_TYPE
                 else:
                     rest_type = types.LONG_TYPE
 
@@ -469,6 +471,10 @@ class MyriaLPlatformTests(object):
     def test_select_double(self):
         q = self.myrial_from_sql(["D3"], "select_double")
         self.check(q, "select_double")
+
+    def test_select_string(self):
+        q = self.myrial_from_sql(["C3"], "select_string")
+        self.check(q, "select_string")
 
     def test_aggregate_double(self):
         self.check_sub_tables("""

--- a/c_test_environment/testqueries/select_string.sql
+++ b/c_test_environment/testqueries/select_string.sql
@@ -1,0 +1,1 @@
+select b from C3;

--- a/c_test_environment/verifier.py
+++ b/c_test_environment/verifier.py
@@ -6,18 +6,21 @@ import nose
 Checks two query outputs for equality
 """
 
-doublepat = re.compile(r'-?\d+[.]\d+')
-def parse_number(number):
-    if doublepat.match(number):
-        n = float(number)
+doublepat = re.compile(r'^-?\d+[.]\d+$')
+intpat = re.compile(r'^-?\d+$')
+def parse_value(value):
+    if doublepat.match(value):
+        n = float(value)
         assert n < pow(2, 40), "decimal place rounding based comparison will be unsound for very large numbers"
         return round(n, 5)
+    elif intpat.match(value):
+        return int(value)
     else:
-        return int(number) 
+        return value
 
 
 def verify(testout, expected, ordered):
-    tuplepat = re.compile(r'Materialized\(([-\d,. ]+)\)')
+    tuplepat = re.compile(r'Materialized\(([-\dA-Z,. ]+)\)')
     test = ({}, [])
     expect = ({}, [])
 
@@ -41,7 +44,7 @@ def verify(testout, expected, ordered):
                     if number=='':
                         # last one
                         break
-                    tlist.append(parse_number(number))
+                    tlist.append(parse_value(number))
 
                 t = tuple(tlist)
                 addTuple(test, t)
@@ -50,7 +53,7 @@ def verify(testout, expected, ordered):
         for line in file.readlines():
             tlist = []
             for number in line.split():
-                tlist.append(parse_number(number))
+                tlist.append(parse_value(number))
 
             t = tuple(tlist)
             addTuple(expect, t)

--- a/raco/language/c_templates/base_query.cpp
+++ b/raco/language/c_templates/base_query.cpp
@@ -8,6 +8,7 @@
 #include <ctype.h>      // for isdigit()
 #include <cstring>
 #include <errno.h>
+#include <algorithm>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/file.h>

--- a/raco/language/c_templates/groupby/0key_scan.cpp
+++ b/raco/language/c_templates/groupby/0key_scan.cpp
@@ -1,4 +1,4 @@
 {
-    {{output_tuple_type}} {{output_tuple_name}}(std::make_tuple({{hashname}}));
+    {{output_tuple_type}} {{output_tuple_name}}({{hashname}});
     {{inner_code}}
 }

--- a/raco/language/c_templates/groupby/1key_scan.cpp
+++ b/raco/language/c_templates/groupby/1key_scan.cpp
@@ -1,4 +1,4 @@
 for (auto it={{hashname}}.begin(); it!={{hashname}}.end(); it++) {
-    {{output_tuple_type}} {{output_tuple_name}}(std::make_tuple(it->first, it->second));
+    {{output_tuple_type}} {{output_tuple_name}}(it->first, it->second);
     {{inner_code}}
 }

--- a/raco/language/c_templates/groupby/2key_scan.cpp
+++ b/raco/language/c_templates/groupby/2key_scan.cpp
@@ -1,4 +1,4 @@
 for (auto it={{hashname}}.begin(); it!={{hashname}}.end(); it++) {
-    {{output_tuple_type}} {{output_tuple_name}}(std::make_tuple(it->first.first, it->first.second, it->second));
+    {{output_tuple_type}} {{output_tuple_name}}(it->first.first, it->first.second, it->second);
     {{inner_code}}
 }

--- a/raco/language/c_templates/hashjoin/lookup.cpp
+++ b/raco/language/c_templates/hashjoin/lookup.cpp
@@ -1,4 +1,4 @@
 for (auto {{right_tuple_name}} : lookup({{hashname}}, {{keyval}})) {
-    auto {{out_tuple_name}} = {{out_tuple_type}}::create({{keyname}}, {{right_tuple_name}});
+    auto {{out_tuple_name}} = create({{keyname}}, {{right_tuple_name}});
     {{inner_plan_compiled}}
 }

--- a/raco/language/c_templates/materialized_tuple_ref_additional.cpp
+++ b/raco/language/c_templates/materialized_tuple_ref_additional.cpp
@@ -1,8 +1,9 @@
 public:
     static {{tupletypename}} fromRelationInfo(relationInfo * rel, int row) {
+        // DOESN'T WORK WITH SCHEMAS WITH STRINGS
       {{tupletypename}} _t;
-      for (int i=0; i<{{numfields}}; i++) {
-         _t._fields[i] = *(void**)(&(rel->relation[row*rel->fields+i]));
-         }
+      {% for ft in fieldtypes %}
+         _t.f{{loop.index-1}} = *({{ft}}*)(&(rel->relation[row*rel->fields+{{loop.index-1}}]));
+      {% endfor %}
       return _t;
     }

--- a/raco/language/cbase_templates/assignment.cpp
+++ b/raco/language/cbase_templates/assignment.cpp
@@ -1,2 +1,2 @@
-{{dst_set_func}}({{src_expr_compiled}});
+{{dst_set_func}} = {{src_expr_compiled}};
 

--- a/raco/language/cbase_templates/materialized_tuple_create_one.cpp
+++ b/raco/language/cbase_templates/materialized_tuple_create_one.cpp
@@ -1,0 +1,8 @@
+static {{result_type}} create(const {{type1}}& t1) {
+    {{result_type}} t;
+    {% for i in range(type1numfields) %}
+        t.f{{i}} = t1.f{{i}};
+    {% endfor %}
+
+    return t;
+}

--- a/raco/language/cbase_templates/materialized_tuple_create_two.cpp
+++ b/raco/language/cbase_templates/materialized_tuple_create_two.cpp
@@ -1,0 +1,12 @@
+static {{result_type}} create(const {{type1}}& t1, const {{type2}}& t2) {
+    {{result_type}} t;
+    {% for i in range(type1numfields) %}
+        t.f{{i}} = t1.f{{i}};
+    {% endfor %}
+
+    {% for i in range(type2numfields) %}
+        t.f{{i+type1numfields}} = t2.f{{i}};
+    {% endfor %}
+
+    return t;
+}

--- a/raco/language/cbase_templates/materialized_tuple_ref.cpp
+++ b/raco/language/cbase_templates/materialized_tuple_ref.cpp
@@ -16,9 +16,18 @@
       // no-op
     }
 
-    template <typename OT>
-    {{tupletypename}} (const OT& other) {
-      std::memcpy(this, &other, sizeof({{tupletypename}}));
+    //template <typename OT>
+    //{{tupletypename}} (const OT& other) {
+    //  std::memcpy(this, &other, sizeof({{tupletypename}}));
+    //}
+    {{tupletypename}} ({% for ft in fieldtypes %}
+                               const {{ft}}& a{{loop.index-1}}
+                               {% if not loop.last %},{% endif %}
+                       {% endfor %}
+                       ) {
+        {% for i in range(numfields) %}
+            f{{i}} = a{{i}};
+        {% endfor %}
     }
 
     // shamelessly terrible disambiguation: one solution is named factory methods

--- a/raco/language/cbase_templates/materialized_tuple_ref.cpp
+++ b/raco/language/cbase_templates/materialized_tuple_ref.cpp
@@ -4,21 +4,9 @@
     // specified by _scheme.
 
     public:
-    static std::tuple<{{ fieldtypes | join(',') }}> _scheme;
-
-    void * _fields[{{numfields}}];
-
-    template <int field>
-    typename std::tuple_element<field,decltype(_scheme)>::type get() const {
-      return *(typename std::tuple_element<field,decltype(_scheme)>::type *)&_fields[field];
-    }
-
-    template <int field, typename T>
-    void set(T val) {
-      // first be sure to convert to proper type, based on scheme
-      typename std::tuple_element<field,decltype(_scheme)>::type __val = val;
-      std::memcpy(&_fields[field], &__val, sizeof(int64_t));
-    }
+    {% for ft in fieldtypes %}
+        {{ft}} f{{loop.index - 1}};
+    {% endfor %}
 
     static constexpr int numFields() {
       return {{numfields}};
@@ -28,84 +16,71 @@
       // no-op
     }
 
-    {{tupletypename}} (const decltype(_fields)& data) {
-      std::memcpy(&_fields, &data, sizeof(_fields));
+    template <typename OT>
+    {{tupletypename}} (const OT& other) {
+      std::memcpy(this, &other, sizeof({{tupletypename}}));
     }
 
     // shamelessly terrible disambiguation: one solution is named factory methods
     {{tupletypename}} (std::vector<int64_t> vals, bool ignore1, bool ignore2) {
-      std::memcpy(&_fields, &vals[0], sizeof(_fields));
+        {% for i in range(numfields) %}
+            f{{i}} = vals[{{i}}];
+        {% endfor %}
     }
 
     // use the tuple schema to interpret the input stream
     static {{tupletypename}} fromIStream(std::istream& ss) {
-        decltype({{tupletypename}}::_scheme) _t;
+        {{tupletypename}} _ret;
 
         ss
         {% for i in range(numfields) %}
-            >> std::get<{{i}}>(_t)
+            >> _ret.f{{i}}
         {% endfor %}
         ;
 
-        {{tupletypename}} _ret;
-        TupleUtils::assign<0, decltype(_scheme)>(_ret._fields, _t);
         return _ret;
     }
 
     void toOStream(std::ostream& os) const {
-       for (int i=0; i<numFields(); i++) {
-         os.write((char *)&_fields[i], sizeof(int64_t));
-       }
+       {% for i in range(numfields) %}
+         {% if fieldtypes[i] == "std::string" %}
+            os.write(f{{i}}.c_str(), std::max(f{{i}}.size(), (size_t)256));
+            os.seekp(std::max(256-f{{i}}.size(), (size_t)0), std::ios_base::cur);
+         {% else %}
+            os.write((char*)&f{{i}}, sizeof({{fieldtypes[i]}}));
+         {% endif %}
+       {% endfor %}
     }
 
     void toOStreamAscii(std::ostream& os) const {
-        TupleUtils::str(os, (void**)_fields, _scheme);
-        os << std::endl;
+        os
+        {% for i in range(numfields-1) %}
+        << f{{i}} << " "
+        {% endfor %}
+        << f{{numfields-1}} << std::endl;
     }
 
-    // note not typesafe!!
-    template <typename T1, typename T2>
-    static {{tupletypename}} create(const T1& t1, const T2& t2) {
-      //TODO: format of assertion for type safe memcpy; fo this for each field
-      //static_assert(!(std::is_integral<typename std::tuple_element<field,decltype(_fields)>::type>::value ^ std::is_integral<T>::value), "Type mismatch");
+    //template <typename Tuple, typename T>
+    //{{tupletypename}} (const Tuple& v0, const T& from) {
+    //    constexpr size_t v0_size = std::tuple_size<Tuple>::value;
+    //    constexpr int from_size = T::numFields();
+    //    static_assert({{tupletypename}}::numFields() == (v0_size + from_size), "constructor only works on same number of total fields");
+    //    TupleUtils::assign<0, decltype(_scheme)>(_fields, v0);
+    //    std::memcpy(((char*)&_fields)+v0_size*sizeof(int64_t), &(from._fields), from_size*sizeof(int64_t));
+    //}
 
-        static_assert({{tupletypename}}::numFields() == (T1::numFields() + T2::numFields()), "lhs and rhs must have equal number of fields");
-        {{tupletypename}} t;
-        std::memcpy(&(t._fields), &(t1._fields), T1::numFields()*sizeof(int64_t));
-        std::memcpy(((char*)&(t._fields))+T1::numFields()*sizeof(int64_t), &(t2._fields), T2::numFields()*sizeof(int64_t));
-        return t;
-    }
-
-    template <typename T>
-    static {{tupletypename}} create(const T& from) {
-      static_assert({{tupletypename}}::numFields() == T::numFields(), "constructor only works on same num fields");
-      {{tupletypename}} t;
-      std::memcpy(&(t._fields), &(from._fields), from.numFields()*sizeof(int64_t));
-      return t;
-    }
-
-    template <typename Tuple, typename T>
-    {{tupletypename}} (const Tuple& v0, const T& from) {
-        constexpr size_t v0_size = std::tuple_size<Tuple>::value;
-        constexpr int from_size = T::numFields();
-        static_assert({{tupletypename}}::numFields() == (v0_size + from_size), "constructor only works on same number of total fields");
-        TupleUtils::assign<0, decltype(_scheme)>(_fields, v0);
-        std::memcpy(((char*)&_fields)+v0_size*sizeof(int64_t), &(from._fields), from_size*sizeof(int64_t));
-    }
-
-    template <typename Tuple>
-    {{tupletypename}} (const Tuple& v0) {
-        static_assert({{tupletypename}}::numFields() == (std::tuple_size<Tuple>::value), "constructor only works on same number of total fields");
-        TupleUtils::assign<0, decltype(_scheme)>(_fields, v0);
-    }
+    //template <typename Tuple>
+    //{{tupletypename}} (const Tuple& v0) {
+    //    static_assert({{tupletypename}}::numFields() == (std::tuple_size<Tuple>::value), "constructor only works on same number of total fields");
+    //    TupleUtils::assign<0, decltype(_scheme)>(_fields, v0);
+    //}
 
     std::ostream& dump(std::ostream& o) const {
       o << "Materialized(";
 
-      // for (int i=0; i<numFields(); i++) {
-      //  o << _fields[i] << ",";
-      // }
-      TupleUtils::str(o, (void**)_fields, _scheme);
+      {% for i in range(numfields) %}
+        o << f{{i}} << ",";
+      {% endfor %}
 
       o << ")";
       return o;
@@ -117,6 +92,4 @@
   std::ostream& operator<< (std::ostream& o, const {{tupletypename}}& t) {
     return t.dump(o);
   }
-
-  std::tuple<{{ fieldtypes | join(',') }}> {{tupletypename}}::_scheme;
 

--- a/raco/language/clang.py
+++ b/raco/language/clang.py
@@ -87,7 +87,7 @@ class CC(CBaseLanguage):
         lookup_init = cls.cgenv().get_template(
             'string_index_lookup.cpp').render(name=sid, st=s)
         build_init = """
-        string_index = build_string_index("sp2bench_1m.index");
+        string_index = build_string_index("sp2bench.index");
         """
         return """(%s)""" % sid, [], [build_init, lookup_init]
         # raise ValueError("String Literals not supported\

--- a/raco/language/clang.py
+++ b/raco/language/clang.py
@@ -20,11 +20,9 @@ import itertools
 
 class CStagedTupleRef(StagedTupleRef):
 
-    def __additionalDefinitionCode__(self):
+    def __additionalDefinitionCode__(self, numfields, fieldtypes):
         constructor_template = CC.cgenv().get_template(
             'materialized_tuple_ref_additional.cpp')
-
-        numfields = len(self.scheme)
 
         tupletypename = self.getTupleTypename()
         return constructor_template.render(locals())
@@ -83,15 +81,7 @@ class CC(CBaseLanguage):
 
     @classmethod
     def compile_stringliteral(cls, s):
-        sid = cls.newstringident()
-        lookup_init = cls.cgenv().get_template(
-            'string_index_lookup.cpp').render(name=sid, st=s)
-        build_init = """
-        string_index = build_string_index("sp2bench.index");
-        """
-        return """(%s)""" % sid, [], [build_init, lookup_init]
-        # raise ValueError("String Literals not supported\
-        # in C language: %s" % s)
+        return '("%s")' % s, [], []
 
 
 class CCOperator(Pipelined, algebra.Operator):

--- a/raco/language/clangcommon.py
+++ b/raco/language/clangcommon.py
@@ -127,9 +127,7 @@ class CBaseLanguage(Language):
             types.LONG_TYPE: 'int64_t',
             types.BOOLEAN_TYPE: 'bool',
             types.DOUBLE_TYPE: 'double',
-
-            # strings are indexed as ints
-            types.STRING_TYPE: 'int64_t'
+            types.STRING_TYPE: 'std::string'
         }.get(raco_type)
 
         assert n is not None, \
@@ -263,13 +261,13 @@ class StagedTupleRef:
 
     @staticmethod
     def get_code_with_name(position, name):
-        return "{name}.get<{position}>()".format(position=position, name=name)
+        return "{name}.f{position}".format(position=position, name=name)
 
     def get_code(self, position):
         return StagedTupleRef.get_code_with_name(position, self.name)
 
     def set_func_code(self, position):
-        return "{name}.set<{position}>".format(
+        return "{name}.f{position}".format(
             position=position, name=self.name)
 
     def generateDefinition(self):
@@ -284,8 +282,8 @@ class StagedTupleRef:
         # ["_ret.set<{i}>(std::get<{i}>(_t));".format(i=i)
         #                        for i in range(numfields)])
 
-        additional_code = self.__additionalDefinitionCode__()
-        after_def_code = self.__afterDefinitionCode__()
+        additional_code = self.__additionalDefinitionCode__(numfields, fieldtypes)
+        after_def_code = self.__afterDefinitionCode__(numfields, fieldtypes)
 
         tupletypename = self.getTupleTypename()
         relsym = self.relsym
@@ -293,10 +291,10 @@ class StagedTupleRef:
         code = template.render(locals())
         return code
 
-    def __additionalDefinitionCode__(self):
+    def __additionalDefinitionCode__(self, numfields, fieldtypes):
         return ""
 
-    def __afterDefinitionCode__(self):
+    def __afterDefinitionCode__(self, numfields, fieldtypes):
         return ""
 
 

--- a/raco/language/clangcommon.py
+++ b/raco/language/clangcommon.py
@@ -126,7 +126,10 @@ class CBaseLanguage(Language):
         n = {
             types.LONG_TYPE: 'int64_t',
             types.BOOLEAN_TYPE: 'bool',
-            types.DOUBLE_TYPE: 'double'
+            types.DOUBLE_TYPE: 'double',
+
+            # strings are indexed as ints
+            types.STRING_TYPE: 'int64_t'
         }.get(raco_type)
 
         assert n is not None, \


### PR DESCRIPTION
Previously strings are supported with an out-of-band indexing step that replaces the strings with integers. This branch adds the string type.

Important:
- this branch breaks grappalang: a tuple stores a STRING_TYPE as a C++ std::string, which has a pointer to a string. In grappalang, since this is not a `GlobalAddress`, strings won't work.
  - suggested fix is to replace `std::string` with `std::array<char, N>` so that the data is stored in the Tuple struct