### PR TITLE
Natively support strings in clang

### DIFF
--- a/c_test_environment/generate_test_relations.py
+++ b/c_test_environment/generate_test_relations.py
@@ -50,15 +50,20 @@ def generate_strings(basename, fields, tuples, datarange):
     fn = get_name(basename, fields)
     with open(fn, 'w') as f:
         print "generating %s" % (os.path.abspath(fn))
+        known_str = "coffee"
+        tuple_with_known = random.randint(0, tuples-1)
         for i in range(0, tuples):
             f.write(str(random.randint(0, datarange)))
             if 0 < (fields - 1):
                 f.write(' ')
             for j in range(1, fields):
-                strmax = 24
-                strlength = random.randint(1, strmax)
-                s = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(strlength))
-                f.write(s)
+                if i == tuple_with_known and j == 1:
+                    f.write(known_str)
+                else:
+                    strmax = 24
+                    strlength = random.randint(1, strmax)
+                    s = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(strlength))
+                    f.write(s)
                 if j < (fields - 1):
                     f.write(' ')
             f.write("\n")

--- a/c_test_environment/generate_test_relations.py
+++ b/c_test_environment/generate_test_relations.py
@@ -1,4 +1,5 @@
 import random
+import string
 import os
 from subprocess import check_call
 
@@ -36,6 +37,28 @@ def generate_random_double(basename, fields, tuples, datarange):
             for j in range(1, fields):
                 dat = random.uniform(0, datarange)
                 f.write(str(dat))
+                if j < (fields - 1):
+                    f.write(' ')
+            f.write("\n")
+
+
+def generate_strings(basename, fields, tuples, datarange):
+    """
+     First attribute is integer and the rest are strings
+    """
+    random.seed(1)
+    fn = get_name(basename, fields)
+    with open(fn, 'w') as f:
+        print "generating %s" % (os.path.abspath(fn))
+        for i in range(0, tuples):
+            f.write(str(random.randint(0, datarange)))
+            if 0 < (fields - 1):
+                f.write(' ')
+            for j in range(1, fields):
+                strmax = 24
+                strlength = random.randint(0, strmax)
+                s = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(strlength))
+                f.write(s)
                 if j < (fields - 1):
                     f.write(' ')
             f.write("\n")
@@ -84,7 +107,8 @@ def gen_files():
                                   ('S', generate_random_int, 3),
                                   ('T', generate_random_int, 3),
                                   ('D', generate_random_double, 1),
-                                  ('I', generate_last_sequential, 3)]:
+                                  ('I', generate_last_sequential, 3),
+                                  ('C', generate_strings, 1)]:
         for nf in [1, 2, 3]:
             yield (n, genfunc, intfields, nf)
 

--- a/c_test_environment/generate_test_relations.py
+++ b/c_test_environment/generate_test_relations.py
@@ -56,7 +56,7 @@ def generate_strings(basename, fields, tuples, datarange):
                 f.write(' ')
             for j in range(1, fields):
                 strmax = 24
-                strlength = random.randint(0, strmax)
+                strlength = random.randint(1, strmax)
                 s = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(strlength))
                 f.write(s)
                 if j < (fields - 1):

--- a/c_test_environment/platform_tests.py
+++ b/c_test_environment/platform_tests.py
@@ -476,6 +476,14 @@ class MyriaLPlatformTests(object):
         q = self.myrial_from_sql(["C3"], "select_string")
         self.check(q, "select_string")
 
+    def test_join_string_val(self):
+        q = self.myrial_from_sql(["C2", "T2"], "join_string_val")
+        self.check(q, "join_string_val")
+
+    def test_join_string_key(self):
+        q = self.myrial_from_sql(["C3", "C3"], "join_string_key")
+        self.check(q, "join_string_key")
+
     def test_aggregate_double(self):
         self.check_sub_tables("""
         D2 = SCAN(%(D2)s);

--- a/c_test_environment/platform_tests.py
+++ b/c_test_environment/platform_tests.py
@@ -484,6 +484,13 @@ class MyriaLPlatformTests(object):
         q = self.myrial_from_sql(["C3", "C3"], "join_string_key")
         self.check(q, "join_string_key")
 
+    def test_groupby_string_key(self):
+        self.check_sub_tables("""
+        C2 = SCAN(%(C2)s);
+        P = [FROM C2 EMIT SUM($0), $1];
+        STORE(P, OUTPUT);
+        """, "groupby_string_key")
+
     def test_aggregate_double(self):
         self.check_sub_tables("""
         D2 = SCAN(%(D2)s);

--- a/c_test_environment/platform_tests.py
+++ b/c_test_environment/platform_tests.py
@@ -491,6 +491,13 @@ class MyriaLPlatformTests(object):
         STORE(P, OUTPUT);
         """, "groupby_string_key")
 
+    def test_groupby_string_multi_key(self):
+        self.check_sub_tables("""
+        C3 = SCAN(%(C3)s);
+        P = [FROM C3 EMIT SUM($0), $1, $2];
+        STORE(P, OUTPUT);
+        """, "groupby_string_multi_key")
+
     def test_aggregate_double(self):
         self.check_sub_tables("""
         D2 = SCAN(%(D2)s);

--- a/c_test_environment/platform_tests.py
+++ b/c_test_environment/platform_tests.py
@@ -151,7 +151,7 @@ class MyriaLPlatformTestHarness(myrial_test.MyrialTestCase):
         super(MyriaLPlatformTestHarness, self).setUp()
 
         self.tables = {}
-        for name in ['R', 'S', 'T', 'I', 'D']:
+        for name in ['R', 'S', 'T', 'I', 'D', 'C']:
             for width in [1, 2, 3]:
                 tablename = "%s%d" % (name, width)
                 fullname = "public:adhoc:%s" % tablename
@@ -159,6 +159,8 @@ class MyriaLPlatformTestHarness(myrial_test.MyrialTestCase):
 
                 if name == 'D':
                     rest_type = types.DOUBLE_TYPE
+                elif name == 'C':
+                    rest_type = types.STRING_TYPE
                 else:
                     rest_type = types.LONG_TYPE
 
@@ -469,6 +471,10 @@ class MyriaLPlatformTests(object):
     def test_select_double(self):
         q = self.myrial_from_sql(["D3"], "select_double")
         self.check(q, "select_double")
+
+    def test_select_string(self):
+        q = self.myrial_from_sql(["C3"], "select_string")
+        self.check(q, "select_string")
 
     def test_aggregate_double(self):
         self.check_sub_tables("""

--- a/c_test_environment/strings.h
+++ b/c_test_environment/strings.h
@@ -57,3 +57,8 @@ std::ostream& operator<<(std::ostream& o, const std::array<char, N>& arr) {
   o << s;
   return o;
 }
+
+template <size_t N>
+bool operator==(const std::array<char, N>& arr, const std::string& str) {
+  return std::string(arr.data()).compare(str) == 0;
+}

--- a/c_test_environment/strings.h
+++ b/c_test_environment/strings.h
@@ -43,7 +43,7 @@ namespace QueryUtils {
 #include <iostream>
 template<size_t N, class Iterable>
 std::array<char, N> to_array(const Iterable& x) {
-  assert(x.size() < N-1);
+  assert(x.size() <= N-1);
   std::array<char, N> d;
   std::copy(x.begin(), x.end(), d.data());
   *(d.data()+x.size()) = '\0'; // copy null terminator

--- a/c_test_environment/strings.h
+++ b/c_test_environment/strings.h
@@ -33,3 +33,27 @@ namespace QueryUtils {
   }
 }
 
+
+
+// for array based strings
+#include <array>
+#include <cassert>
+#define MAX_STR_LEN 256
+
+#include <iostream>
+template<size_t N, class Iterable>
+std::array<char, N> to_array(const Iterable& x) {
+  assert(x.size() < N-1);
+  std::array<char, N> d;
+  std::copy(x.begin(), x.end(), d.data());
+  *(d.data()+x.size()) = '\0'; // copy null terminator
+  return d;
+}
+
+template <size_t N>
+std::ostream& operator<<(std::ostream& o, const std::array<char, N>& arr) {
+  // copy to a string so null terminator is used  
+  std::string s(arr.data());
+  o << s;
+  return o;
+}

--- a/c_test_environment/testqueries/groupby_string_key.sql
+++ b/c_test_environment/testqueries/groupby_string_key.sql
@@ -1,0 +1,2 @@
+select sum(C2.a), C2.b from C2
+group by C2.b; 

--- a/c_test_environment/testqueries/groupby_string_multi_key.sql
+++ b/c_test_environment/testqueries/groupby_string_multi_key.sql
@@ -1,0 +1,2 @@
+select sum(C3.a), C3.b, C3.c from C3
+group by C3.b, C3.c

--- a/c_test_environment/testqueries/join_string_key.sql
+++ b/c_test_environment/testqueries/join_string_key.sql
@@ -1,0 +1,2 @@
+select r1.a, r2.a from C3 r1, C3 r2 where r1.b=r2.c;
+

--- a/c_test_environment/testqueries/join_string_val.sql
+++ b/c_test_environment/testqueries/join_string_val.sql
@@ -1,0 +1,2 @@
+select C2.b, T2.b from C2, T2 where C2.a=T2.a;
+

--- a/c_test_environment/testqueries/select_string.sql
+++ b/c_test_environment/testqueries/select_string.sql
@@ -1,0 +1,1 @@
+select b from C3;

--- a/c_test_environment/testqueries/select_string_literal.sql
+++ b/c_test_environment/testqueries/select_string_literal.sql
@@ -1,0 +1,1 @@
+select * from C3 where b = "coffee";

--- a/c_test_environment/testqueries/string_join.sql
+++ b/c_test_environment/testqueries/string_join.sql
@@ -1,0 +1,2 @@
+select C2.b, T2.b from C2, T2 where C2.a=T2.a;
+

--- a/c_test_environment/utils.h
+++ b/c_test_environment/utils.h
@@ -5,6 +5,7 @@
 #include <utility>
 #include <tuple>
 #include <cstring>
+#include <array>
 
 uint64_t identity_hash( int64_t k );
 
@@ -36,6 +37,20 @@ namespace std {
         return h1 ^ (h2 << 1);
       }
     };
+}
+
+namespace std {
+  template<size_t N>
+  struct hash<std::array<char, N>>
+  {
+      typedef std::array<char, N> argument_type;
+      typedef std::size_t result_type;
+
+      result_type operator()(argument_type const& s) const {
+        // use the std::hash for std::string
+        return std::hash<std::string>()(std::string(s.data()));
+      }
+  };
 }
 
 

--- a/c_test_environment/verifier.py
+++ b/c_test_environment/verifier.py
@@ -6,18 +6,21 @@ import nose
 Checks two query outputs for equality
 """
 
-doublepat = re.compile(r'-?\d+[.]\d+')
-def parse_number(number):
-    if doublepat.match(number):
-        n = float(number)
+doublepat = re.compile(r'^-?\d+[.]\d+$')
+intpat = re.compile(r'^-?\d+$')
+def parse_value(value):
+    if doublepat.match(value):
+        n = float(value)
         assert n < pow(2, 40), "decimal place rounding based comparison will be unsound for very large numbers"
         return round(n, 5)
+    elif intpat.match(value):
+        return int(value)
     else:
-        return int(number) 
+        return value
 
 
 def verify(testout, expected, ordered):
-    tuplepat = re.compile(r'Materialized\(([-\d,. ]+)\)')
+    tuplepat = re.compile(r'Materialized\(([-\dA-Z,. ]+)\)')
     test = ({}, [])
     expect = ({}, [])
 
@@ -41,7 +44,7 @@ def verify(testout, expected, ordered):
                     if number=='':
                         # last one
                         break
-                    tlist.append(parse_number(number))
+                    tlist.append(parse_value(number))
 
                 t = tuple(tlist)
                 addTuple(test, t)
@@ -50,7 +53,7 @@ def verify(testout, expected, ordered):
         for line in file.readlines():
             tlist = []
             for number in line.split():
-                tlist.append(parse_number(number))
+                tlist.append(parse_value(number))
 
             t = tuple(tlist)
             addTuple(expect, t)

--- a/c_test_environment/verifier.py
+++ b/c_test_environment/verifier.py
@@ -12,7 +12,7 @@ def parse_value(value):
     if doublepat.match(value):
         n = float(value)
         assert n < pow(2, 40), "decimal place rounding based comparison will be unsound for very large numbers"
-        return round(n, 5)
+        return round(n, 2)
     elif intpat.match(value):
         return int(value)
     else:

--- a/c_test_environment/verifier.py
+++ b/c_test_environment/verifier.py
@@ -20,7 +20,7 @@ def parse_value(value):
 
 
 def verify(testout, expected, ordered):
-    tuplepat = re.compile(r'Materialized\(([-\dA-Z,. ]+)\)')
+    tuplepat = re.compile(r'Materialized\(([-\dA-Za-z,. ]+)\)')
     test = ({}, [])
     expect = ({}, [])
 

--- a/raco/language/c_templates/base_query.cpp
+++ b/raco/language/c_templates/base_query.cpp
@@ -8,6 +8,7 @@
 #include <ctype.h>      // for isdigit()
 #include <cstring>
 #include <errno.h>
+#include <algorithm>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/file.h>

--- a/raco/language/c_templates/groupby/0key_scan.cpp
+++ b/raco/language/c_templates/groupby/0key_scan.cpp
@@ -1,4 +1,4 @@
 {
-    {{output_tuple_type}} {{output_tuple_name}}(std::make_tuple({{hashname}}));
+    {{output_tuple_type}} {{output_tuple_name}}({{hashname}});
     {{inner_code}}
 }

--- a/raco/language/c_templates/groupby/1key_scan.cpp
+++ b/raco/language/c_templates/groupby/1key_scan.cpp
@@ -1,4 +1,4 @@
 for (auto it={{hashname}}.begin(); it!={{hashname}}.end(); it++) {
-    {{output_tuple_type}} {{output_tuple_name}}(std::make_tuple(it->first, it->second));
+    {{output_tuple_type}} {{output_tuple_name}}(it->first, it->second);
     {{inner_code}}
 }

--- a/raco/language/c_templates/groupby/2key_scan.cpp
+++ b/raco/language/c_templates/groupby/2key_scan.cpp
@@ -1,4 +1,4 @@
 for (auto it={{hashname}}.begin(); it!={{hashname}}.end(); it++) {
-    {{output_tuple_type}} {{output_tuple_name}}(std::make_tuple(it->first.first, it->first.second, it->second));
+    {{output_tuple_type}} {{output_tuple_name}}(it->first.first, it->first.second, it->second);
     {{inner_code}}
 }

--- a/raco/language/c_templates/hashjoin/lookup.cpp
+++ b/raco/language/c_templates/hashjoin/lookup.cpp
@@ -1,4 +1,4 @@
 for (auto {{right_tuple_name}} : lookup({{hashname}}, {{keyval}})) {
-    auto {{out_tuple_name}} = create({{keyname}}, {{right_tuple_name}});
+    auto {{out_tuple_name}} = {{append_func_name}}({{keyname}}, {{right_tuple_name}});
     {{inner_plan_compiled}}
 }

--- a/raco/language/c_templates/hashjoin/lookup.cpp
+++ b/raco/language/c_templates/hashjoin/lookup.cpp
@@ -1,4 +1,4 @@
 for (auto {{right_tuple_name}} : lookup({{hashname}}, {{keyval}})) {
-    auto {{out_tuple_name}} = {{out_tuple_type}}::create({{keyname}}, {{right_tuple_name}});
+    auto {{out_tuple_name}} = create({{keyname}}, {{right_tuple_name}});
     {{inner_plan_compiled}}
 }

--- a/raco/language/c_templates/materialized_tuple_ref_additional.cpp
+++ b/raco/language/c_templates/materialized_tuple_ref_additional.cpp
@@ -1,8 +1,9 @@
 public:
     static {{tupletypename}} fromRelationInfo(relationInfo * rel, int row) {
+        // DOESN'T WORK WITH SCHEMAS WITH STRINGS
       {{tupletypename}} _t;
-      for (int i=0; i<{{numfields}}; i++) {
-         _t._fields[i] = *(void**)(&(rel->relation[row*rel->fields+i]));
-         }
+      {% for ft in fieldtypes %}
+         _t.f{{loop.index-1}} = *({{ft}}*)(&(rel->relation[row*rel->fields+{{loop.index-1}}]));
+      {% endfor %}
       return _t;
     }

--- a/raco/language/cbase_templates/assignment.cpp
+++ b/raco/language/cbase_templates/assignment.cpp
@@ -1,2 +1,2 @@
-{{dst_set_func}}({{src_expr_compiled}});
+{{dst_set_func}} = {{src_expr_compiled}};
 

--- a/raco/language/cbase_templates/materialized_tuple_create_one.cpp
+++ b/raco/language/cbase_templates/materialized_tuple_create_one.cpp
@@ -1,0 +1,8 @@
+static {{result_type}} create(const {{type1}}& t1) {
+    {{result_type}} t;
+    {% for i in range(type1numfields) %}
+        t.f{{i}} = t1.f{{i}};
+    {% endfor %}
+
+    return t;
+}

--- a/raco/language/cbase_templates/materialized_tuple_create_one.cpp
+++ b/raco/language/cbase_templates/materialized_tuple_create_one.cpp
@@ -1,4 +1,4 @@
-static {{result_type}} create(const {{type1}}& t1) {
+static {{result_type}} {{convert_func_name}}(const {{type1}}& t1) {
     {{result_type}} t;
     {% for i in range(type1numfields) %}
         t.f{{i}} = t1.f{{i}};

--- a/raco/language/cbase_templates/materialized_tuple_create_two.cpp
+++ b/raco/language/cbase_templates/materialized_tuple_create_two.cpp
@@ -1,0 +1,12 @@
+static {{result_type}} create(const {{type1}}& t1, const {{type2}}& t2) {
+    {{result_type}} t;
+    {% for i in range(type1numfields) %}
+        t.f{{i}} = t1.f{{i}};
+    {% endfor %}
+
+    {% for i in range(type2numfields) %}
+        t.f{{i+type1numfields}} = t2.f{{i}};
+    {% endfor %}
+
+    return t;
+}

--- a/raco/language/cbase_templates/materialized_tuple_create_two.cpp
+++ b/raco/language/cbase_templates/materialized_tuple_create_two.cpp
@@ -1,4 +1,4 @@
-static {{result_type}} create(const {{type1}}& t1, const {{type2}}& t2) {
+static {{result_type}} {{append_func_name}}(const {{type1}}& t1, const {{type2}}& t2) {
     {{result_type}} t;
     {% for i in range(type1numfields) %}
         t.f{{i}} = t1.f{{i}};

--- a/raco/language/cbase_templates/materialized_tuple_ref.cpp
+++ b/raco/language/cbase_templates/materialized_tuple_ref.cpp
@@ -16,9 +16,18 @@
       // no-op
     }
 
-    template <typename OT>
-    {{tupletypename}} (const OT& other) {
-      std::memcpy(this, &other, sizeof({{tupletypename}}));
+    //template <typename OT>
+    //{{tupletypename}} (const OT& other) {
+    //  std::memcpy(this, &other, sizeof({{tupletypename}}));
+    //}
+    {{tupletypename}} ({% for ft in fieldtypes %}
+                               const {{ft}}& a{{loop.index-1}}
+                               {% if not loop.last %},{% endif %}
+                       {% endfor %}
+                       ) {
+        {% for i in range(numfields) %}
+            f{{i}} = a{{i}};
+        {% endfor %}
     }
 
     // shamelessly terrible disambiguation: one solution is named factory methods

--- a/raco/language/cbase_templates/materialized_tuple_ref.cpp
+++ b/raco/language/cbase_templates/materialized_tuple_ref.cpp
@@ -39,14 +39,45 @@
         {% endfor %}
     }
 
-    {{tupletypename}}(const std::tuple<{% for ft in fieldtypes %}
-                                   {{ft}}
-                                   {% if not loop.last %},{% endif %}
-                                   {% endfor %}>& o) {
+    {# list of types comma separated #}
+    {# TODO: uncomment when jinja 2.8 is released with support for set blocks
+    {% set types_comma %}
+        {% for ft in fieldtypes %}
+        {{ft}}
+        {% if not loop.last %},{% endif %}
+        {% endfor %}
+    {% endset %}
+    #}
 
+
+    {{tupletypename}}(const std::tuple<
+        {% for ft in fieldtypes %}
+        {{ft}}
+        {% if not loop.last %},{% endif %}
+        {% endfor %}
+            >& o) {
         {% for i in range(numfields) %}
             f{{i}} = std::get<{{i}}>(o);
         {% endfor %}
+     }
+
+     std::tuple<
+        {% for ft in fieldtypes %}
+        {{ft}}
+        {% if not loop.last %},{% endif %}
+        {% endfor %}
+     > to_tuple() {
+
+        std::tuple<
+        {% for ft in fieldtypes %}
+        {{ft}}
+        {% if not loop.last %},{% endif %}
+        {% endfor %}
+        > r;
+        {% for i in range(numfields) %}
+            std::get<{{i}}>(r) = f{{i}};
+        {% endfor %}
+        return r;
      }
 
     // shamelessly terrible disambiguation: one solution is named factory methods

--- a/raco/language/cbase_templates/materialized_tuple_ref.cpp
+++ b/raco/language/cbase_templates/materialized_tuple_ref.cpp
@@ -12,6 +12,15 @@
       return {{numfields}};
     }
 
+    static size_t fieldsSize() {
+        const {{tupletypename}} _t;
+        return
+        {% for i in range(numfields) %}
+        sizeof(_t.f{{i}}) +
+        {% endfor %}
+        0;
+    }
+
     {{tupletypename}} () {
       // no-op
     }

--- a/raco/language/cbase_templates/materialized_tuple_ref.cpp
+++ b/raco/language/cbase_templates/materialized_tuple_ref.cpp
@@ -4,21 +4,9 @@
     // specified by _scheme.
 
     public:
-    static std::tuple<{{ fieldtypes | join(',') }}> _scheme;
-
-    void * _fields[{{numfields}}];
-
-    template <int field>
-    typename std::tuple_element<field,decltype(_scheme)>::type get() const {
-      return *(typename std::tuple_element<field,decltype(_scheme)>::type *)&_fields[field];
-    }
-
-    template <int field, typename T>
-    void set(T val) {
-      // first be sure to convert to proper type, based on scheme
-      typename std::tuple_element<field,decltype(_scheme)>::type __val = val;
-      std::memcpy(&_fields[field], &__val, sizeof(int64_t));
-    }
+    {% for ft in fieldtypes %}
+        {{ft}} f{{loop.index - 1}};
+    {% endfor %}
 
     static constexpr int numFields() {
       return {{numfields}};
@@ -28,84 +16,71 @@
       // no-op
     }
 
-    {{tupletypename}} (const decltype(_fields)& data) {
-      std::memcpy(&_fields, &data, sizeof(_fields));
+    template <typename OT>
+    {{tupletypename}} (const OT& other) {
+      std::memcpy(this, &other, sizeof({{tupletypename}}));
     }
 
     // shamelessly terrible disambiguation: one solution is named factory methods
     {{tupletypename}} (std::vector<int64_t> vals, bool ignore1, bool ignore2) {
-      std::memcpy(&_fields, &vals[0], sizeof(_fields));
+        {% for i in range(numfields) %}
+            f{{i}} = vals[{{i}}];
+        {% endfor %}
     }
 
     // use the tuple schema to interpret the input stream
     static {{tupletypename}} fromIStream(std::istream& ss) {
-        decltype({{tupletypename}}::_scheme) _t;
+        {{tupletypename}} _ret;
 
         ss
         {% for i in range(numfields) %}
-            >> std::get<{{i}}>(_t)
+            >> _ret.f{{i}}
         {% endfor %}
         ;
 
-        {{tupletypename}} _ret;
-        TupleUtils::assign<0, decltype(_scheme)>(_ret._fields, _t);
         return _ret;
     }
 
     void toOStream(std::ostream& os) const {
-       for (int i=0; i<numFields(); i++) {
-         os.write((char *)&_fields[i], sizeof(int64_t));
-       }
+       {% for i in range(numfields) %}
+         {% if fieldtypes[i] == "std::string" %}
+            os.write(f{{i}}.c_str(), std::max(f{{i}}.size(), (size_t)256));
+            os.seekp(std::max(256-f{{i}}.size(), (size_t)0), std::ios_base::cur);
+         {% else %}
+            os.write((char*)&f{{i}}, sizeof({{fieldtypes[i]}}));
+         {% endif %}
+       {% endfor %}
     }
 
     void toOStreamAscii(std::ostream& os) const {
-        TupleUtils::str(os, (void**)_fields, _scheme);
-        os << std::endl;
+        os
+        {% for i in range(numfields-1) %}
+        << f{{i}} << " "
+        {% endfor %}
+        << f{{numfields-1}} << std::endl;
     }
 
-    // note not typesafe!!
-    template <typename T1, typename T2>
-    static {{tupletypename}} create(const T1& t1, const T2& t2) {
-      //TODO: format of assertion for type safe memcpy; fo this for each field
-      //static_assert(!(std::is_integral<typename std::tuple_element<field,decltype(_fields)>::type>::value ^ std::is_integral<T>::value), "Type mismatch");
+    //template <typename Tuple, typename T>
+    //{{tupletypename}} (const Tuple& v0, const T& from) {
+    //    constexpr size_t v0_size = std::tuple_size<Tuple>::value;
+    //    constexpr int from_size = T::numFields();
+    //    static_assert({{tupletypename}}::numFields() == (v0_size + from_size), "constructor only works on same number of total fields");
+    //    TupleUtils::assign<0, decltype(_scheme)>(_fields, v0);
+    //    std::memcpy(((char*)&_fields)+v0_size*sizeof(int64_t), &(from._fields), from_size*sizeof(int64_t));
+    //}
 
-        static_assert({{tupletypename}}::numFields() == (T1::numFields() + T2::numFields()), "lhs and rhs must have equal number of fields");
-        {{tupletypename}} t;
-        std::memcpy(&(t._fields), &(t1._fields), T1::numFields()*sizeof(int64_t));
-        std::memcpy(((char*)&(t._fields))+T1::numFields()*sizeof(int64_t), &(t2._fields), T2::numFields()*sizeof(int64_t));
-        return t;
-    }
-
-    template <typename T>
-    static {{tupletypename}} create(const T& from) {
-      static_assert({{tupletypename}}::numFields() == T::numFields(), "constructor only works on same num fields");
-      {{tupletypename}} t;
-      std::memcpy(&(t._fields), &(from._fields), from.numFields()*sizeof(int64_t));
-      return t;
-    }
-
-    template <typename Tuple, typename T>
-    {{tupletypename}} (const Tuple& v0, const T& from) {
-        constexpr size_t v0_size = std::tuple_size<Tuple>::value;
-        constexpr int from_size = T::numFields();
-        static_assert({{tupletypename}}::numFields() == (v0_size + from_size), "constructor only works on same number of total fields");
-        TupleUtils::assign<0, decltype(_scheme)>(_fields, v0);
-        std::memcpy(((char*)&_fields)+v0_size*sizeof(int64_t), &(from._fields), from_size*sizeof(int64_t));
-    }
-
-    template <typename Tuple>
-    {{tupletypename}} (const Tuple& v0) {
-        static_assert({{tupletypename}}::numFields() == (std::tuple_size<Tuple>::value), "constructor only works on same number of total fields");
-        TupleUtils::assign<0, decltype(_scheme)>(_fields, v0);
-    }
+    //template <typename Tuple>
+    //{{tupletypename}} (const Tuple& v0) {
+    //    static_assert({{tupletypename}}::numFields() == (std::tuple_size<Tuple>::value), "constructor only works on same number of total fields");
+    //    TupleUtils::assign<0, decltype(_scheme)>(_fields, v0);
+    //}
 
     std::ostream& dump(std::ostream& o) const {
       o << "Materialized(";
 
-      // for (int i=0; i<numFields(); i++) {
-      //  o << _fields[i] << ",";
-      // }
-      TupleUtils::str(o, (void**)_fields, _scheme);
+      {% for i in range(numfields) %}
+        o << f{{i}} << ",";
+      {% endfor %}
 
       o << ")";
       return o;
@@ -117,6 +92,4 @@
   std::ostream& operator<< (std::ostream& o, const {{tupletypename}}& t) {
     return t.dump(o);
   }
-
-  std::tuple<{{ fieldtypes | join(',') }}> {{tupletypename}}::_scheme;
 

--- a/raco/language/cbase_templates/materialized_tuple_ref.cpp
+++ b/raco/language/cbase_templates/materialized_tuple_ref.cpp
@@ -39,6 +39,16 @@
         {% endfor %}
     }
 
+    {{tupletypename}}(const std::tuple<{% for ft in fieldtypes %}
+                                   {{ft}}
+                                   {% if not loop.last %},{% endif %}
+                                   {% endfor %}>& o) {
+
+        {% for i in range(numfields) %}
+            f{{i}} = std::get<{{i}}>(o);
+        {% endfor %}
+     }
+
     // shamelessly terrible disambiguation: one solution is named factory methods
     //{{tupletypename}} (std::vector<int64_t> vals, bool ignore1, bool ignore2) {
     //    {% for i in range(numfields) %}

--- a/raco/language/cbase_templates/union.cpp
+++ b/raco/language/cbase_templates/union.cpp
@@ -1,3 +1,3 @@
-{{unified_tuple_typename}} {{unified_tuple_name}} = {{unified_tuple_typename}}::create({{src_tuple_name}});
+{{unified_tuple_typename}} {{unified_tuple_name}} = {{convert_func_name}}({{src_tuple_name}});
 {{inner_plan_compiled}}
 

--- a/raco/language/clang.py
+++ b/raco/language/clang.py
@@ -406,12 +406,11 @@ class CHashJoin(algebra.Join, CCOperator):
             type1numfields = len(t.scheme)
             type2 = self.right_type
             type2numfields = len(self.right.scheme())
-
-            append_func_name = "create_" + gensym()
-
-            result_type = out_tuple_type
-            combine_function_def = self._cgenv.get_template(
-                "materialized_tuple_create_two.cpp").render(locals())
+            append_func_name, combine_function_def = \
+                CStagedTupleRef.get_append(
+                    out_tuple_type,
+                    type1, type1numfields,
+                    type2, type2numfields)
 
             state.addDeclarations([out_tuple_type_def, combine_function_def])
 

--- a/raco/language/clang.py
+++ b/raco/language/clang.py
@@ -87,7 +87,7 @@ class CC(CBaseLanguage):
         lookup_init = cls.cgenv().get_template(
             'string_index_lookup.cpp').render(name=sid, st=s)
         build_init = """
-        string_index = build_string_index("sp2bench_1m.index");
+        string_index = build_string_index("sp2bench.index");
         """
         return """(%s)""" % sid, [], [build_init, lookup_init]
         # raise ValueError("String Literals not supported\

--- a/raco/language/clang.py
+++ b/raco/language/clang.py
@@ -20,11 +20,9 @@ import itertools
 
 class CStagedTupleRef(StagedTupleRef):
 
-    def __additionalDefinitionCode__(self):
+    def __additionalDefinitionCode__(self, numfields, fieldtypes):
         constructor_template = CC.cgenv().get_template(
             'materialized_tuple_ref_additional.cpp')
-
-        numfields = len(self.scheme)
 
         tupletypename = self.getTupleTypename()
         return constructor_template.render(locals())
@@ -83,15 +81,7 @@ class CC(CBaseLanguage):
 
     @classmethod
     def compile_stringliteral(cls, s):
-        sid = cls.newstringident()
-        lookup_init = cls.cgenv().get_template(
-            'string_index_lookup.cpp').render(name=sid, st=s)
-        build_init = """
-        string_index = build_string_index("sp2bench.index");
-        """
-        return """(%s)""" % sid, [], [build_init, lookup_init]
-        # raise ValueError("String Literals not supported\
-        # in C language: %s" % s)
+        return '("%s")' % s, [], []
 
 
 class CCOperator(Pipelined, algebra.Operator):

--- a/raco/language/clang.py
+++ b/raco/language/clang.py
@@ -79,10 +79,6 @@ class CC(CBaseLanguage):
     def log_file_unquoted(code, level=0):
         return """logfile << %s << " ";\n """ % code
 
-    @classmethod
-    def compile_stringliteral(cls, s):
-        return '(%s)' % s, [], []
-
 
 class CCOperator(Pipelined, algebra.Operator):
     _language = CC

--- a/raco/language/clangcommon.py
+++ b/raco/language/clangcommon.py
@@ -127,9 +127,7 @@ class CBaseLanguage(Language):
             types.LONG_TYPE: 'int64_t',
             types.BOOLEAN_TYPE: 'bool',
             types.DOUBLE_TYPE: 'double',
-
-            # strings are indexed as ints
-            types.STRING_TYPE: 'int64_t'
+            types.STRING_TYPE: 'std::string'
         }.get(raco_type)
 
         assert n is not None, \
@@ -263,13 +261,13 @@ class StagedTupleRef:
 
     @staticmethod
     def get_code_with_name(position, name):
-        return "{name}.get<{position}>()".format(position=position, name=name)
+        return "{name}.f{position}".format(position=position, name=name)
 
     def get_code(self, position):
         return StagedTupleRef.get_code_with_name(position, self.name)
 
     def set_func_code(self, position):
-        return "{name}.set<{position}>".format(
+        return "{name}.f{position}".format(
             position=position, name=self.name)
 
     def generateDefinition(self):
@@ -284,8 +282,8 @@ class StagedTupleRef:
         # ["_ret.set<{i}>(std::get<{i}>(_t));".format(i=i)
         #                        for i in range(numfields)])
 
-        additional_code = self.__additionalDefinitionCode__()
-        after_def_code = self.__afterDefinitionCode__()
+        additional_code = self.__additionalDefinitionCode__(numfields, fieldtypes)
+        after_def_code = self.__afterDefinitionCode__(numfields, fieldtypes)
 
         tupletypename = self.getTupleTypename()
         relsym = self.relsym
@@ -293,10 +291,10 @@ class StagedTupleRef:
         code = template.render(locals())
         return code
 
-    def __additionalDefinitionCode__(self):
+    def __additionalDefinitionCode__(self, numfields, fieldtypes):
         return ""
 
-    def __afterDefinitionCode__(self):
+    def __afterDefinitionCode__(self, numfields, fieldtypes):
         return ""
 
 

--- a/raco/language/clangcommon.py
+++ b/raco/language/clangcommon.py
@@ -132,7 +132,7 @@ class CBaseLanguage(Language):
             types.LONG_TYPE: 'int64_t',
             types.BOOLEAN_TYPE: 'bool',
             types.DOUBLE_TYPE: 'double',
-            types.STRING_TYPE: 'std::string'
+            types.STRING_TYPE: 'std::array<char, MAX_STR_LEN>'
         }.get(raco_type)
 
         assert n is not None, \
@@ -282,6 +282,8 @@ class StagedTupleRef:
 
         fieldtypes = [CBaseLanguage.typename(t)
                       for t in self.scheme.get_types()]
+
+        string_type_name = CBaseLanguage.typename(types.STRING_TYPE)
 
         # stream_sets = emitlist(
         # ["_ret.set<{i}>(std::get<{i}>(_t));".format(i=i)

--- a/raco/language/clangcommon.py
+++ b/raco/language/clangcommon.py
@@ -289,7 +289,9 @@ class StagedTupleRef:
         # ["_ret.set<{i}>(std::get<{i}>(_t));".format(i=i)
         #                        for i in range(numfields)])
 
-        additional_code = self.__additionalDefinitionCode__(numfields, fieldtypes)
+        additional_code = self.__additionalDefinitionCode__(
+            numfields,
+            fieldtypes)
         after_def_code = self.__afterDefinitionCode__(numfields, fieldtypes)
 
         tupletypename = self.getTupleTypename()
@@ -343,6 +345,14 @@ class CBaseUnionAll(Pipelined, algebra.Union):
         unified_tuple_typename = self.unifiedTupleType.getTupleTypename()
         unified_tuple_name = self.unifiedTupleType.name
         src_tuple_name = t.name
+
+        # add declaration for function to convert from one type to the other
+        type1 = t.getTupleTypename()
+        type1numfields = len(t.scheme)
+        convert_func_name = "create_" + gensym()
+        result_type = unified_tuple_typename
+        convert_func = _cgenv.get_template('materialized_tuple_create_one.cpp').render(locals())
+        state.addDeclarations([convert_func])
 
         inner_plan_compiled = \
             self.parent().consume(self.unifiedTupleType, self, state)

--- a/raco/language/clangcommon.py
+++ b/raco/language/clangcommon.py
@@ -179,6 +179,10 @@ class CBaseLanguage(Language):
         assert False, "{expr} is unsupported attribute".format(expr=expr)
 
     @classmethod
+    def compile_stringliteral(cls, s):
+        return '(%s)' % s, [], []
+
+    @classmethod
     def ifelse(cls, when_compiled, else_compiled):
         if_template = """
         if ({cond}) {{

--- a/raco/language/clangcommon.py
+++ b/raco/language/clangcommon.py
@@ -30,6 +30,7 @@ def prepend_template_relpath(env, relpath):
 
 
 class CBaseLanguage(Language):
+
     @classmethod
     def c_stringify(cls, st):
         """ turn " in the string into \" since C ' are chars
@@ -246,6 +247,17 @@ _cgenv = CBaseLanguage.__get_env_for_template_libraries__()
 
 class StagedTupleRef:
     nextid = 0
+
+    @staticmethod
+    def get_append(out_tuple_type, type1, type1numfields,
+                   type2, type2numfields):
+
+        append_func_name = "create_" + gensym()
+
+        result_type = out_tuple_type
+        combine_function_def = _cgenv.get_template(
+            "materialized_tuple_create_two.cpp").render(locals())
+        return append_func_name, combine_function_def
 
     @classmethod
     def genname(cls):

--- a/raco/language/clangcommon.py
+++ b/raco/language/clangcommon.py
@@ -351,7 +351,8 @@ class CBaseUnionAll(Pipelined, algebra.Union):
         type1numfields = len(t.scheme)
         convert_func_name = "create_" + gensym()
         result_type = unified_tuple_typename
-        convert_func = _cgenv.get_template('materialized_tuple_create_one.cpp').render(locals())
+        convert_func = _cgenv.get_template(
+            'materialized_tuple_create_one.cpp').render(locals())
         state.addDeclarations([convert_func])
 
         inner_plan_compiled = \

--- a/raco/language/clangcommon.py
+++ b/raco/language/clangcommon.py
@@ -126,7 +126,10 @@ class CBaseLanguage(Language):
         n = {
             types.LONG_TYPE: 'int64_t',
             types.BOOLEAN_TYPE: 'bool',
-            types.DOUBLE_TYPE: 'double'
+            types.DOUBLE_TYPE: 'double',
+
+            # strings are indexed as ints
+            types.STRING_TYPE: 'int64_t'
         }.get(raco_type)
 
         assert n is not None, \

--- a/raco/language/grappa_templates/groupby/multi_uda_0key_output.cpp
+++ b/raco/language/grappa_templates/groupby/multi_uda_0key_output.cpp
@@ -1,7 +1,7 @@
 {% extends '0key_output.cpp' %}
 
 {% block templateargs %}
-{{state_type}}, &{{update_func}}
+{{state_type}}, &{{combine_func}}
 {% endblock %}
 
 {% block output %}

--- a/raco/language/grappa_templates/groupby/multi_uda_0key_output.cpp
+++ b/raco/language/grappa_templates/groupby/multi_uda_0key_output.cpp
@@ -5,5 +5,5 @@
 {% endblock %}
 
 {% block output %}
-{{output_tuple_type}} {{output_tuple_name}} = {{output_tuple_type}}::create({{output_tuple_name}}_tmp);
+{{output_tuple_type}} {{output_tuple_name}}({{output_tuple_name}}_tmp);
 {% endblock %}

--- a/raco/language/grappa_templates/groupby/multi_uda_scan.cpp
+++ b/raco/language/grappa_templates/groupby/multi_uda_scan.cpp
@@ -1,4 +1,4 @@
 {% extends 'scan.cpp' %}
 
 {# depends on materialized_tuple_ref constructor of std::tuple #}
-{% block initializer %}{{ super() }}, {{mapping_var_name}}.second.to_tuple(){% endblock %}
+{% block initializer %}std::tuple_cat({{ super() }}, {{mapping_var_name}}.second.to_tuple()){% endblock %}

--- a/raco/language/grappa_templates/groupby/multi_uda_scan.cpp
+++ b/raco/language/grappa_templates/groupby/multi_uda_scan.cpp
@@ -1,3 +1,4 @@
 {% extends 'scan.cpp' %}
 
-{% block initializer %}{{ super() }}, {{mapping_var_name}}.second{% endblock %}
+{# depends on materialized_tuple_ref constructor of std::tuple #}
+{% block initializer %}{{ super() }}, {{mapping_var_name}}.second.to_tuple(){% endblock %}

--- a/raco/language/grappa_templates/groupby/one_built_in_0key_output.cpp
+++ b/raco/language/grappa_templates/groupby/one_built_in_0key_output.cpp
@@ -4,6 +4,6 @@
 
 {% block output %}
 {{output_tuple_type}} {{output_tuple_name}};
-{{output_tuple_set_func}}({{output_tuple_name}}_tmp);
+{{output_tuple_set_func}} = {{output_tuple_name}}_tmp;
 {% endblock %}
 

--- a/raco/language/grappa_templates/groupby/one_built_in_0key_output.cpp
+++ b/raco/language/grappa_templates/groupby/one_built_in_0key_output.cpp
@@ -1,6 +1,6 @@
 {% extends '0key_output.cpp' %}
 
-{% block templateargs %}{{state_type}}, counter, &{{update_func}}, &get_count{% endblock %}
+{% block templateargs %}{{state_type}}, counter<{{state_type}}>, &{{update_func}}, &get_count<{{state_type}}>{% endblock %}
 
 {% block output %}
 {{output_tuple_type}} {{output_tuple_name}};

--- a/raco/language/grappa_templates/groupby/one_built_in_0key_output.cpp
+++ b/raco/language/grappa_templates/groupby/one_built_in_0key_output.cpp
@@ -1,6 +1,6 @@
 {% extends '0key_output.cpp' %}
 
-{% block templateargs %}{{state_type}}, counter<{{state_type}}>, &{{update_func}}, &get_count<{{state_type}}>{% endblock %}
+{% block templateargs %}{{state_type}}, counter<{{state_type}}>, &{{combine_func}}, &get_count<{{state_type}}>{% endblock %}
 
 {% block output %}
 {{output_tuple_type}} {{output_tuple_name}};

--- a/raco/language/grappa_templates/groupby/one_built_in_scan.cpp
+++ b/raco/language/grappa_templates/groupby/one_built_in_scan.cpp
@@ -1,3 +1,4 @@
 {% extends 'scan.cpp' %}
 
+{# depends on materialized_tuple_ref constructor of std::tuple #}
 {% block initializer %}std::tuple_cat({{ super() }}, std::make_tuple({{mapping_var_name}}.second)){% endblock %}

--- a/raco/language/grappa_templates/hashjoin/lookup.cpp
+++ b/raco/language/grappa_templates/hashjoin/lookup.cpp
@@ -1,5 +1,5 @@
 {{hashname}}.lookup_iter<&{{pipeline_sync}}>( {{keyval}}, [=]({{right_tuple_type}}& {{right_tuple_name}}) {
   join_coarse_result_count++;
-  {{out_tuple_type}} {{out_tuple_name}} = {{out_tuple_type}}::create<{{input_tuple_type}}, {{right_tuple_type}}>({{keyname}}, {{right_tuple_name}});
+  {{out_tuple_type}} {{out_tuple_name}} = {{append_func_name}}({{keyname}}, {{right_tuple_name}});
   {{inner_plan_compiled}}
 });

--- a/raco/language/grappa_templates/symmetrichashjoin/hash_insert_lookup.cpp
+++ b/raco/language/grappa_templates/symmetrichashjoin/hash_insert_lookup.cpp
@@ -3,4 +3,3 @@
   {{out_tuple_type}} {{out_tuple_name}} = {{append_func_name}}({{left_name}}, {{right_name}});
   {{inner_plan_compiled}}
 });
-kk

--- a/raco/language/grappa_templates/symmetrichashjoin/hash_insert_lookup.cpp
+++ b/raco/language/grappa_templates/symmetrichashjoin/hash_insert_lookup.cpp
@@ -1,5 +1,6 @@
 {{hashname}}.insert_lookup_iter_{{side}}<&{{global_syncname}}>({{keyval}}, {{keyname}}, [=]({{other_tuple_type}} {{valname}}) {
   join_coarse_result_count++;
-  {{out_tuple_type}} {{out_tuple_name}} = {{out_tuple_type}}::create<{{left_type}}, {{right_type}}> ({{left_name}}, {{right_name}});
+  {{out_tuple_type}} {{out_tuple_name}} = {{append_func_name}}({{left_name}}, {{right_name}});
   {{inner_plan_compiled}}
 });
+kk

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -554,7 +554,7 @@ class GrappaGroupBy(clangcommon.BaseCGroupby, GrappaOperator):
 
     def _init_func_for_op(self, op):
         r = {
-            aggregate.MAX: 'std::numeric_limits::min'
+            aggregate.MAX: 'std::numeric_limits::min',
             aggregate.MIN: 'std::numeric_limits::max'
         }.get(op.__class__)
         if r is None:

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -552,6 +552,14 @@ class GrappaGroupBy(clangcommon.BaseCGroupby, GrappaOperator):
         else:
             return update_op
 
+    def _init_func_for_op(self, op):
+        r = {
+            aggregate.MAX: 'std::numeric_limits::min()',
+            aggregate.MIN: 'std::numeric_limits::max()'
+        }.get(op.__class__)
+        if r is None:
+            return 'Aggregates::Zero'
+
     def produce(self, state):
         self._agg_mode = None
         if len(self.aggregate_list) == 1 \
@@ -745,7 +753,7 @@ class GrappaGroupBy(clangcommon.BaseCGroupby, GrappaOperator):
 
         # form code to fill in the materialize template
         if self._agg_mode == self._ONE_BUILT_IN:
-            init_func = "Aggregates::Zero"
+            init_func = self._init_func_for_op(self.aggregate_list[0])
 
             if isinstance(self.aggregate_list[0], expression.ZeroaryOperator):
                 # no value needed for Zero-input aggregate,

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -1070,6 +1070,7 @@ def grappify(join_type, emit_print):
         rules.OneToOne(algebra.Union, GrappaUnionAll),
         clangcommon.StoreToBaseCStore(emit_print, GrappaStore),
 
+        # Don't need this because we support two-key
         # clangcommon.BreakHashJoinConjunction(GrappaSelect, join_type)
     ]
 

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -333,6 +333,14 @@ class GrappaSymmetricHashJoin(GrappaJoin, GrappaOperator):
             self.right_name = right_name
             valname = left_name
 
+            append_func_name, combine_function_def = \
+                GrappaStagedTupleRef.get_append(
+                    out_tuple_type,
+                    left_type, len(left_sch),
+                    right_type, len(t.scheme))
+
+            state.addDeclarations([combine_function_def])
+
             code = access_template.render(locals())
             return code
 
@@ -931,7 +939,17 @@ class GrappaHashJoin(GrappaJoin, GrappaOperator):
             out_tuple_type = outTuple.getTupleTypename()
             out_tuple_name = outTuple.name
 
-            state.addDeclarations([out_tuple_type_def])
+            type1 = input_tuple_type
+            type1numfields = len(t.scheme)
+            type2 = right_tuple_type
+            type2numfields = len(self.right.scheme())
+            append_func_name, combine_function_def = \
+                GrappaStagedTupleRef.get_append(
+                    out_tuple_type,
+                    type1, type1numfields,
+                    type2, type2numfields)
+
+            state.addDeclarations([out_tuple_type_def, combine_function_def])
 
             inner_plan_compiled = self.parent().consume(outTuple, self, state)
 

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -554,8 +554,8 @@ class GrappaGroupBy(clangcommon.BaseCGroupby, GrappaOperator):
 
     def _init_func_for_op(self, op):
         r = {
-            aggregate.MAX: 'std::numeric_limits::min()',
-            aggregate.MIN: 'std::numeric_limits::max()'
+            aggregate.MAX: 'std::numeric_limits::min'
+            aggregate.MIN: 'std::numeric_limits::max'
         }.get(op.__class__)
         if r is None:
             return 'Aggregates::Zero'

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -554,7 +554,7 @@ class GrappaGroupBy(clangcommon.BaseCGroupby, GrappaOperator):
 
     def _init_func_for_op(self, op):
         r = {
-            aggregate.MAX: 'std::numeric_limits<{0}>::min',
+            aggregate.MAX: 'std::numeric_limits<{0}>::lowest',
             aggregate.MIN: 'std::numeric_limits<{0}>::max'
         }.get(op.__class__)
         if r is None:

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -554,8 +554,8 @@ class GrappaGroupBy(clangcommon.BaseCGroupby, GrappaOperator):
 
     def _init_func_for_op(self, op):
         r = {
-            aggregate.MAX: 'std::numeric_limits::min',
-            aggregate.MIN: 'std::numeric_limits::max'
+            aggregate.MAX: 'std::numeric_limits<{0}>::min',
+            aggregate.MIN: 'std::numeric_limits<{0}>::max'
         }.get(op.__class__)
         if r is None:
             return 'Aggregates::Zero'
@@ -755,7 +755,6 @@ class GrappaGroupBy(clangcommon.BaseCGroupby, GrappaOperator):
 
         # form code to fill in the materialize template
         if self._agg_mode == self._ONE_BUILT_IN:
-            init_func = self._init_func_for_op(self.aggregate_list[0])
 
             if isinstance(self.aggregate_list[0], expression.ZeroaryOperator):
                 # no value needed for Zero-input aggregate,
@@ -771,6 +770,9 @@ class GrappaGroupBy(clangcommon.BaseCGroupby, GrappaOperator):
             update_val = inputTuple.get_code(valpos)
             input_type = self.language().typename(
                 self.aggregate_list[0].input.typeof(inp_sch, None))
+
+            init_func = self._init_func_for_op(self.aggregate_list[0])\
+                .format(input_type)
 
         elif self._agg_mode == self._MULTI_UDA:
             init_func = "{name}_init".format(name=self.func_name)

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -544,9 +544,11 @@ class GrappaGroupBy(clangcommon.BaseCGroupby, GrappaOperator):
             '{0}/groupby'.format(GrappaLanguage._template_path))
 
     def _combiner_for_builtin_update(self, update_op):
-        # put special cases where update_op != combiner_op
-        if update_op == aggregate.COUNT or update_op == aggregate.COUNTALL:
-            return aggregate.SUM
+        # FIXME: should be using get_decomposable_state instead of this hack
+        # FIXME: need AVG and STDEV
+        if update_op.__class__ == aggregate.COUNT \
+                or update_op.__class__ == aggregate.COUNTALL:
+            return aggregate.SUM(update_op.input)
         else:
             return update_op
 

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -339,7 +339,8 @@ class GrappaSymmetricHashJoin(GrappaJoin, GrappaOperator):
                     left_type, len(left_sch),
                     right_type, len(t.scheme))
 
-            state.addDeclarations([combine_function_def])
+            # need to add later because requires left tuple type decl
+            self.right_combine_decl = combine_function_def
 
             code = access_template.render(locals())
             return code
@@ -366,7 +367,8 @@ class GrappaSymmetricHashJoin(GrappaJoin, GrappaOperator):
                     left_type, len(t.scheme),
                     right_type, len(self.right.scheme()))
 
-            state.addDeclarations([combine_function_def])
+            state.addDeclarations([self.right_combine_decl,
+                                   combine_function_def])
 
             code = access_template.render(locals())
             return code

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -26,7 +26,7 @@ def define_cl_arg(type, name, default_value, description):
 
 class GrappaStagedTupleRef(StagedTupleRef):
 
-    def __afterDefinitionCode__(self):
+    def __afterDefinitionCode__(self, numfields, fieldtypes):
         # Grappa requires structures to be block aligned if they will be
         # iterated over with localizing forall
         return "GRAPPA_BLOCK_ALIGNED"

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -125,21 +125,6 @@ class GrappaLanguage(CBaseLanguage):
 
         return apply_wrappers(plcode, wrappers)
 
-    @classmethod
-    def compile_stringliteral(cls, st):
-        st = cls.c_stringify(st)
-        sid = cls.newstringident()
-        decl = """int64_t %s;""" % (sid)
-        lookup_init = GrappaLanguage.cgenv().get_template(
-            'string_index_lookup.cpp').render(locals())
-        build_init = """
-        string_index = build_string_index("sp2bench.index");
-        """
-
-        return """(%s)""" % sid, [decl], [build_init, lookup_init]
-        # raise ValueError("String Literals not supported in
-        # C language: %s" % s)
-
 
 class GrappaOperator (Pipelined, algebra.Operator):
     _language = GrappaLanguage

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -559,6 +559,8 @@ class GrappaGroupBy(clangcommon.BaseCGroupby, GrappaOperator):
         }.get(op.__class__)
         if r is None:
             return 'Aggregates::Zero'
+        else:
+            return r
 
     def produce(self, state):
         self._agg_mode = None

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -360,6 +360,14 @@ class GrappaSymmetricHashJoin(GrappaJoin, GrappaOperator):
             right_name = gensym()
             valname = right_name
 
+            append_func_name, combine_function_def = \
+                GrappaStagedTupleRef.get_append(
+                    out_tuple_type,
+                    left_type, len(t.scheme),
+                    right_type, len(self.right.scheme()))
+
+            state.addDeclarations([combine_function_def])
+
             code = access_template.render(locals())
             return code
 

--- a/raco/platform_tests.py
+++ b/raco/platform_tests.py
@@ -528,6 +528,10 @@ class MyriaLPlatformTests(object):
         STORE(P, OUTPUT);
         """, "groupby_string_multi_key")
 
+    def test_select_string_literal(self):
+        q = self.myrial_from_sql(["C3"], "select_string_literal")
+        self.check(q, "select_string_literal")
+
     def test_aggregate_double(self):
         self.check_sub_tables("""
         D2 = SCAN(%(D2)s);


### PR DESCRIPTION
Previously strings are supported with an out-of-band indexing step that replaces the strings with integers. This branch adds the string type.

Important:

this branch breaks grappalang: a tuple stores a `STRING_TYPE` as a C++ `std::string`, which has a pointer to a string. In grappalang, since this is not a GlobalAddress, strings won't work.
suggested fix is to replace `std::string` with `std::array<char, N>` so that the data is stored in the Tuple struct

- [x] array refactoring
- [x] test grappa running
- [x] grappa ci tests pass (52)

replaces #400 to change base branch