### PR TITLE
adding ability to print the plan in python repr and read from repr

### DIFF
--- a/c_test_environment/repr_myrial_tests.py
+++ b/c_test_environment/repr_myrial_tests.py
@@ -1,0 +1,27 @@
+import unittest
+from generate_test_relations import generate_default
+from generate_test_relations import need_generate
+from raco.language.myrialang import MyriaLeftDeepTreeAlgebra
+from platform_tests import MyriaLPlatformTestHarness, MyriaLPlatformTests
+from raco.from_repr import plan_from_repr
+
+import sys
+sys.path.append('./examples')
+from osutils import Chdir
+
+
+class MyriaLReprTest(MyriaLPlatformTestHarness, MyriaLPlatformTests):
+    def check(self, query, name, **kwargs):
+        kwargs['target_alg'] = MyriaLeftDeepTreeAlgebra()
+        plan = self.get_physical_plan(query, **kwargs)
+        assert plan == plan_from_repr(repr(plan))
+
+    def setUp(self):
+        super(MyriaLReprTest, self).setUp()
+        with Chdir("c_test_environment") as d:
+            if need_generate():
+                generate_default()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/raco/from_repr.py
+++ b/raco/from_repr.py
@@ -1,0 +1,25 @@
+# import all the expressions and algebras
+
+from raco.language.myrialang import *
+from raco.language.clang import *
+from raco.language.clangcommon import *
+from raco.language.grappalang import *
+from raco.algebra import *
+from raco.scheme import *
+from raco.expression.expression import *
+from raco.expression.aggregate import *
+from raco.types import *
+from raco.relation_key import *
+from raco.expression.boolean import *
+
+
+import logging
+logging.basicConfig()
+_LOG = logging.getLogger(name=__name__)
+
+
+def plan_from_repr(repr_string):
+    _LOG.warning("Relying on eval! "
+                 "This module should only be used in "
+                 "trusted development situations\n")
+    return eval(repr_string)

--- a/raco/language/clang.py
+++ b/raco/language/clang.py
@@ -430,23 +430,23 @@ def indentby(code, level):
 
 # iteration  over table + insertion into hash table with filter
 
-class CUnionAll(clangcommon.CUnionAll, CCOperator):
+class CUnionAll(clangcommon.CBaseUnionAll, CCOperator):
     pass
 
 
-class CApply(clangcommon.CApply, CCOperator):
+class CApply(clangcommon.CBaseApply, CCOperator):
     pass
 
 
-class CProject(clangcommon.CProject, CCOperator):
+class CProject(clangcommon.CBaseProject, CCOperator):
     pass
 
 
-class CSelect(clangcommon.CSelect, CCOperator):
+class CSelect(clangcommon.CBaseSelect, CCOperator):
     pass
 
 
-class CFileScan(clangcommon.CFileScan, CCOperator):
+class CFileScan(clangcommon.CBaseFileScan, CCOperator):
 
     def __get_ascii_scan_template__(self):
         return CC.cgenv().get_template('ascii_scan.cpp')
@@ -459,7 +459,7 @@ class CFileScan(clangcommon.CFileScan, CCOperator):
         return CC.cgenv().get_template('relation_declaration.cpp')
 
 
-class CStore(clangcommon.BaseCStore, CCOperator):
+class CStore(clangcommon.CBaseStore, CCOperator):
 
     def __file_code__(self, t, state):
         output_stream_symbol = "outputfile"

--- a/raco/language/clangcommon.py
+++ b/raco/language/clangcommon.py
@@ -305,7 +305,7 @@ class StagedTupleRef:
         return ""
 
 
-class CSelect(Pipelined, algebra.Select):
+class CBaseSelect(Pipelined, algebra.Select):
 
     def produce(self, state):
         self.input.produce(state)
@@ -328,7 +328,7 @@ class CSelect(Pipelined, algebra.Select):
         return code
 
 
-class CUnionAll(Pipelined, algebra.Union):
+class CBaseUnionAll(Pipelined, algebra.Union):
 
     def produce(self, state):
         self.unifiedTupleType = self.new_tuple_ref(gensym(), self.scheme())
@@ -349,7 +349,7 @@ class CUnionAll(Pipelined, algebra.Union):
         return union_template.render(locals())
 
 
-class CApply(Pipelined, algebra.Apply):
+class CBaseApply(Pipelined, algebra.Apply):
 
     def produce(self, state):
         # declare a single new type for project
@@ -393,7 +393,7 @@ class CApply(Pipelined, algebra.Apply):
         return code
 
 
-class CProject(Pipelined, algebra.Project):
+class CBaseProject(Pipelined, algebra.Project):
 
     def produce(self, state):
         # declare a single new type for project
@@ -433,7 +433,7 @@ class CProject(Pipelined, algebra.Project):
 from raco.algebra import ZeroaryOperator
 
 
-class CFileScan(Pipelined, algebra.Scan):
+class CBaseFileScan(Pipelined, algebra.Scan):
 
     @abc.abstractmethod
     def __get_ascii_scan_template__(self):
@@ -569,10 +569,10 @@ EMIT_CONSOLE = 'console'
 EMIT_FILE = 'file'
 
 
-class BaseCStore(Pipelined, algebra.Store):
+class CBaseStore(Pipelined, algebra.Store):
 
     def __init__(self, emit_print, relation_key, plan):
-        super(BaseCStore, self).__init__(relation_key, plan)
+        super(CBaseStore, self).__init__(relation_key, plan)
         self.emit_print = emit_print
 
     def produce(self, state):
@@ -608,8 +608,8 @@ class StoreToBaseCStore(rules.Rule):
 
     def __init__(self, emit_print, subclass):
         self.emit_print = emit_print
-        assert issubclass(subclass, BaseCStore), \
-            "%s is not a subclass of %s" % (subclass, BaseCStore)
+        assert issubclass(subclass, CBaseStore), \
+            "%s is not a subclass of %s" % (subclass, CBaseStore)
         self.subclass = subclass
 
     def fire(self, expr):

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -941,26 +941,26 @@ def indentby(code, level):
 
 
 # Basic selection like serial C++
-class GrappaSelect(clangcommon.CSelect, GrappaOperator):
+class GrappaSelect(clangcommon.CBaseSelect, GrappaOperator):
     pass
 
 
 # Basic apply like serial C++
-class GrappaApply(clangcommon.CApply, GrappaOperator):
+class GrappaApply(clangcommon.CBaseApply, GrappaOperator):
     pass
 
 
 # Basic duplication based bag union like serial C++
-class GrappaUnionAll(clangcommon.CUnionAll, GrappaOperator):
+class GrappaUnionAll(clangcommon.CBaseUnionAll, GrappaOperator):
     pass
 
 
 # Basic materialized copy based project like serial C++
-class GrappaProject(clangcommon.CProject, GrappaOperator):
+class GrappaProject(clangcommon.CBaseProject, GrappaOperator):
     pass
 
 
-class GrappaFileScan(clangcommon.CFileScan, GrappaOperator):
+class GrappaFileScan(clangcommon.CBaseFileScan, GrappaOperator):
 
     def __get_ascii_scan_template__(self):
         _LOG.warn("binary/ascii is command line choice")
@@ -974,7 +974,7 @@ class GrappaFileScan(clangcommon.CFileScan, GrappaOperator):
         return self._language.cgenv().get_template('relation_declaration.cpp')
 
 
-class GrappaStore(clangcommon.BaseCStore, GrappaOperator):
+class GrappaStore(clangcommon.CBaseStore, GrappaOperator):
 
     def __file_code__(self, t, state):
         my_sch = self.scheme()

--- a/raco/myrial/interpreter.py
+++ b/raco/myrial/interpreter.py
@@ -436,6 +436,15 @@ class StatementProcessor(object):
     def get_json(self, **kwargs):
         lp = self.get_logical_plan()
         pps = self.get_physical_plan(**kwargs)
+
         # TODO This is not correct. The first argument is the raw query string,
         # not the string representation of the logical plan
         return compile_to_json(str(lp), pps, pps, "myrial")
+
+    @classmethod
+    def get_json_from_physical_plan(cls, pp):
+        pps = pp
+
+        # TODO This is not correct. The first argument is the raw query string,
+        # not the string representation of the logical plan
+        return compile_to_json("NOT_SOURCED_FROM_LOGICAL_RA", pps, pps, "myrial")

--- a/raco/myrial/interpreter.py
+++ b/raco/myrial/interpreter.py
@@ -447,4 +447,5 @@ class StatementProcessor(object):
 
         # TODO This is not correct. The first argument is the raw query string,
         # not the string representation of the logical plan
-        return compile_to_json("NOT_SOURCED_FROM_LOGICAL_RA", pps, pps, "myrial")
+        return compile_to_json(
+            "NOT_SOURCED_FROM_LOGICAL_RA", pps, pps, "myrial")

--- a/scripts/myrial
+++ b/scripts/myrial
@@ -17,6 +17,7 @@ from raco.viz import operator_to_dot
 from raco.myrial.exceptions import *
 from raco.language.grappalang import GrappaAlgebra
 from raco.language.logical import OptLogicalAlgebra
+import raco.from_repr as from_repr
 from raco.compile import compile
 
 
@@ -64,8 +65,9 @@ def parse_options(args):
     arg_parser.add_argument('-v', dest='verbose', action='store_true',
                        help='Turn on verbose DEBUG logging')
     arg_parser.add_argument('--catalog', dest="catalog_path", default=None, help="[Optional] path to catalog file")
+    arg_parser.add_argument('--plan', dest="from_repr", action='store_true', help="[Optional] input file is a plan as a python repr")
     arg_parser.add_argument('file',
-                            help='File containing MyriaL source program')
+                            help='File containing MyriaL source program (or a physical plan if using --plan)')
 
     ns = arg_parser.parse_args(args)
     return ns
@@ -91,44 +93,95 @@ def main(args):
     _parser = parser.Parser()
     processor = interpreter.StatementProcessor(catalog, True)
 
+    statement_list = None
+    plan_repr = None
     with open(opt.file) as fh:
         try:
-            statement_list = _parser.parse(fh.read())
+            inp = fh.read()
+            if opt.from_repr:
+                plan_repr = inp
+            else:
+                statement_list = _parser.parse(inp)
         except MyrialCompileException as ex:
             print 'MyriaL parse error: %s' % ex
             return 1
 
-        if opt.parse:
-            print statement_list
+    if opt.parse:
+        if statement_list == None:
+            print "No MyriaL given"
         else:
+            print statement_list
+    else:
+        if opt.from_repr:
+            pd = PhysicalPlanDispatch(from_repr=plan_repr)
+        else:
+            pd = PhysicalPlanDispatch(processor=processor)
             processor.evaluate(statement_list)
-            if opt.logical:
-                print_pretty_plan(processor.get_logical_plan())
-            elif opt.dot:
-                print operator_to_dot(processor.get_logical_plan())
-            elif opt.json:
-                print json.dumps(processor.get_json())
-            elif opt.standalone:
-                pp = processor.get_physical_plan()
-                db = FakeDatabase()
-                db.evaluate(pp)
-            elif opt.repr:
-                pp = processor.get_physical_plan()
-                print repr(pp)
-            elif opt.opt_logical:
-                print_pretty_plan(processor.get_physical_plan(
-                    target_alg=OptLogicalAlgebra()))
-            elif opt.clang:
-                pp = processor.get_physical_plan(target_alg=GrappaAlgebra())
-                print_pretty_plan(pp)
-                c = compile(pp)
-                fname = '{0}.cpp'.format(os.path.splitext(os.path.basename(opt.file))[0])
-                with open(fname, 'w') as f:
-                    f.write(c)
-            else:
-                print_pretty_plan(processor.get_physical_plan())
+
+        if opt.logical:
+            if opt.from_repr:
+                raise "Options logical and --plan are incompatible"
+            print_pretty_plan(processor.get_logical_plan())
+        elif opt.dot:
+            if opt.from_repr:
+                raise "Options dot and --plan are incompatible"
+            print operator_to_dot(processor.get_logical_plan())
+        elif opt.json:
+            ppj = pd.get_json()
+            print(json.dumps(ppj))
+        elif opt.standalone:
+            pp = pd.get_physical_plan()
+            db = FakeDatabase()
+            db.evaluate(pp)
+        elif opt.repr:
+            pp = pd.get_physical_plan()
+            print repr(pp)
+        elif opt.opt_logical:
+            if opt.from_repr:
+                raise "Options opt_logical and --plan are incompatible"
+            print_pretty_plan(processor.get_physical_plan(
+                target_alg=OptLogicalAlgebra()))
+        elif opt.clang:
+            pp = pd.get_physical_plan(target_alg=GrappaAlgebra())
+            print_pretty_plan(pp)
+            c = compile(pp)
+            fname = '{0}.cpp'.format(os.path.splitext(os.path.basename(opt.file))[0])
+            with open(fname, 'w') as f:
+                f.write(c)
+        else:
+            print_pretty_plan(pd.get_physical_plan())
 
     return 0
+
+
+class PhysicalPlanDispatch(object):
+
+    def __init__(self, processor=None, from_repr=None):
+        if processor:
+            self.processor = processor
+            self.with_repr = None
+        elif from_repr:
+            self.processor = None
+            self.with_repr = from_repr
+        else:
+            raise "Requires processor or repr plan input"
+
+    def get_physical_plan(self, target_alg=None):
+        if self.with_repr:
+            return from_repr.plan_from_repr(self.with_repr)
+        else:
+            if target_alg is None:
+                return self.processor.get_physical_plan()
+            else:
+                return self.processor.get_physical_plan(target_alg=target_alg)
+
+    def get_json(self):
+        if self.with_repr:
+            return interpreter.StatementProcessor.get_json_from_physical_plan(self.get_physical_plan())
+        else:
+            return self.processor.get_json()
+
+
 
 if __name__ == "__main__":
     sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
fixes #412 

Note that this feature should only be used in the developer client because it relies on `eval`. It is only exposed in scripts/myrial, which is not used by any server code (myria-web uses raco `processor` API directly)