### PR TITLE
Write to Catalog File

### DIFF
--- a/raco/catalog.py
+++ b/raco/catalog.py
@@ -6,6 +6,7 @@ from ast import literal_eval
 import os
 import json
 
+
 class Relation(object):
 
     def __init__(self, name, sch):
@@ -151,7 +152,7 @@ class FromFileCatalog(Catalog):
             current_dict[new_rel_key] = columns
             json.dump(current_dict, schema_write)
             schema_write.close()
-        else: 
+        else:
             with open(path, 'w+') as fh:
                 d = {}
                 d[new_rel_key] = columns

--- a/raco/catalog.py
+++ b/raco/catalog.py
@@ -4,7 +4,7 @@ from raco.relation_key import RelationKey
 from raco.scheme import Scheme
 from ast import literal_eval
 import os
-
+import json
 
 class Relation(object):
 
@@ -133,6 +133,30 @@ class FromFileCatalog(Catalog):
     def load_from_file(cls, path):
         with open(path) as fh:
             return cls(literal_eval(fh.read()), path)
+
+    @classmethod
+    def scheme_write_to_file(cls, path, new_rel_key, new_rel_schema):
+        new_schema_entry = literal_eval(new_rel_schema)
+        col_names = new_schema_entry['columnNames']
+        col_types = new_schema_entry['columnTypes']
+        columns = zip(col_names, col_types)
+
+        if(os.path.isfile(path)):
+            schema_read = open(path, 'r')
+            s = schema_read.read()
+            schema_read.close()
+
+            schema_write = open(path, 'w')
+            current_dict = literal_eval(s)
+            current_dict[new_rel_key] = columns
+            json.dump(current_dict, schema_write)
+            schema_write.close()
+        else: 
+            with open(path, 'w+') as fh:
+                d = {}
+                d[new_rel_key] = columns
+                json.dump(d, fh)
+            fh.close()
 
     def get_num_servers(self):
         return 1

--- a/raco/catalog.py
+++ b/raco/catalog.py
@@ -136,22 +136,26 @@ class FromFileCatalog(Catalog):
             return cls(literal_eval(fh.read()), path)
 
     @classmethod
-    def scheme_write_to_file(cls, path, new_rel_key, new_rel_schema):
+    def scheme_write_to_file(cls, path, new_rel_key, new_rel_schema,
+                             append=True):
         new_schema_entry = literal_eval(new_rel_schema)
         col_names = new_schema_entry['columnNames']
         col_types = new_schema_entry['columnTypes']
         columns = zip(col_names, col_types)
 
-        if(os.path.isfile(path)):
-            schema_read = open(path, 'r')
-            s = schema_read.read()
-            schema_read.close()
+        if os.path.isfile(path):
+            if append:
+                schema_read = open(path, 'r')
+                s = schema_read.read()
+                schema_read.close()
 
-            schema_write = open(path, 'w')
-            current_dict = literal_eval(s)
-            current_dict[new_rel_key] = columns
-            json.dump(current_dict, schema_write)
-            schema_write.close()
+                schema_write = open(path, 'w')
+                current_dict = literal_eval(s)
+                current_dict[new_rel_key] = columns
+                json.dump(current_dict, schema_write)
+                schema_write.close()
+            else:
+                raise IOError("file {0} exists".format(path))
         else:
             with open(path, 'w+') as fh:
                 d = {}

--- a/raco/catalog_tests/test_catalog.py
+++ b/raco/catalog_tests/test_catalog.py
@@ -37,3 +37,17 @@ class TestFromFileCatalog(unittest.TestCase):
 
         with self.assertRaises(Exception):
             cut.get_scheme('D')
+
+    def test_schema_to_file(self):
+        rel_to_add = 'public:adhoc:test'
+        FromFileCatalog.scheme_write_to_file(
+            "{p}/test_write_catalog.py".format(p=test_file_path), rel_to_add,
+            "{'columnNames': ['grpID'], 'columnTypes': ['LONG_TYPE']}")
+
+        cut = FromFileCatalog.load_from_file(
+            "{p}/test_write_catalog.py".format(p=test_file_path))
+
+        self.assertEqual(cut.get_scheme(rel_to_add).get_names(),
+                         ['grpID'])
+        self.assertEqual(cut.get_scheme(rel_to_add).get_types(),
+                         ['LONG_TYPE'])

--- a/raco/catalog_tests/test_catalog.py
+++ b/raco/catalog_tests/test_catalog.py
@@ -8,6 +8,7 @@ test_file_path = "raco/catalog_tests"
 
 
 class TestFromFileCatalog(unittest.TestCase):
+
     def test_default_cardinality_relation(self):
         cut = FromFileCatalog.load_from_file(
             "{p}/default_cardinality_relation.py".format(p=test_file_path))
@@ -100,7 +101,7 @@ class TestFromFileCatalog(unittest.TestCase):
 
         with self.assertRaises(IOError):
             FromFileCatalog.scheme_write_to_file(
-                "{p}/test_write_catalog.py".format(p=test_file_path), rel_to_add,
+                "{p}/test_write_catalog.py".format(p=test_file_path),
+                rel_to_add,
                 "{'columnNames': ['grpID'], 'columnTypes': ['LONG_TYPE']}",
                 append=False)
-

--- a/raco/catalog_tests/test_catalog.py
+++ b/raco/catalog_tests/test_catalog.py
@@ -2,6 +2,7 @@ import unittest
 
 from raco.catalog import FromFileCatalog
 from raco.catalog import DEFAULT_CARDINALITY
+import os
 
 test_file_path = "raco/catalog_tests"
 
@@ -39,9 +40,14 @@ class TestFromFileCatalog(unittest.TestCase):
             cut.get_scheme('D')
 
     def test_schema_to_file(self):
+        file = "{p}/test_write_catalog.py".format(p=test_file_path)
+
+        if os.path.isfile(file):
+            os.remove(file)
+
         rel_to_add = 'public:adhoc:test'
         FromFileCatalog.scheme_write_to_file(
-            "{p}/test_write_catalog.py".format(p=test_file_path), rel_to_add,
+            file, rel_to_add,
             "{'columnNames': ['grpID'], 'columnTypes': ['LONG_TYPE']}")
 
         cut = FromFileCatalog.load_from_file(
@@ -51,3 +57,50 @@ class TestFromFileCatalog(unittest.TestCase):
                          ['grpID'])
         self.assertEqual(cut.get_scheme(rel_to_add).get_types(),
                          ['LONG_TYPE'])
+
+    def test_schema_append_to_file(self):
+        file = "{p}/test_write_catalog.py".format(p=test_file_path)
+
+        if os.path.isfile(file):
+            os.remove(file)
+
+        rel_to_add1 = 'public:adhoc:test1'
+        rel_to_add2 = 'public:adhoc:test2'
+
+        FromFileCatalog.scheme_write_to_file(
+            file, rel_to_add1,
+            "{'columnNames': ['grpID1'], 'columnTypes': ['LONG_TYPE']}")
+
+        FromFileCatalog.scheme_write_to_file(
+            file, rel_to_add2,
+            "{'columnNames': ['grpID2'], 'columnTypes': ['STRING_TYPE']}")
+
+        cut = FromFileCatalog.load_from_file(
+            "{p}/test_write_catalog.py".format(p=test_file_path))
+
+        self.assertEqual(cut.get_scheme(rel_to_add1).get_names(),
+                         ['grpID1'])
+        self.assertEqual(cut.get_scheme(rel_to_add1).get_types(),
+                         ['LONG_TYPE'])
+        self.assertEqual(cut.get_scheme(rel_to_add2).get_names(),
+                         ['grpID2'])
+        self.assertEqual(cut.get_scheme(rel_to_add2).get_types(),
+                         ['STRING_TYPE'])
+
+    def test_schema_to_file_no_append(self):
+        file = "{p}/test_write_catalog.py".format(p=test_file_path)
+
+        if os.path.isfile(file):
+            os.remove(file)
+
+        rel_to_add = 'public:adhoc:test'
+        FromFileCatalog.scheme_write_to_file(
+            "{p}/test_write_catalog.py".format(p=test_file_path), rel_to_add,
+            "{'columnNames': ['grpID'], 'columnTypes': ['LONG_TYPE']}")
+
+        with self.assertRaises(IOError):
+            FromFileCatalog.scheme_write_to_file(
+                "{p}/test_write_catalog.py".format(p=test_file_path), rel_to_add,
+                "{'columnNames': ['grpID'], 'columnTypes': ['LONG_TYPE']}",
+                append=False)
+


### PR DESCRIPTION
We want to have a way for users to write the schema directly to a file from a call instead of writing it on the file separately. For example: 

```FromFileCatalog.scheme_write_to_file("schema2.py","public:adhoc:newTable", "{'columnNames': ['grpID'], 'columnTypes': ['LONG_TYPE']}")```

```catalog = FromFileCatalog.load_from_file("schema2.py")```

In the future, once we do have a Myria connection in Raco, it would be nice to do something like the following (I'm using Myria-Python high-level calls in this example): 

```connection = MyriaConnection(hostname = "rest.myria.cs.washington.edu", port=1776, ssl=True ...)```

```current_schema = (MyriaRelation(relation="public:adhoc:newTable", connection=connection).schema.to_dict())```

```FromFileCatalog.scheme_write_to_file("schema2.py","public:adhoc:newTable", current_schema)```