### PR TITLE
add comments to operator code, so it is easier for humans to read

### DIFF
--- a/raco/language/clangcommon.py
+++ b/raco/language/clangcommon.py
@@ -406,7 +406,7 @@ class CBaseApply(Pipelined, algebra.Apply):
         self.input.produce(state)
 
     def consume(self, t, src, state):
-        code = ""
+        code = self.language().comment(self.shortStr())
 
         assignment_template = _cgenv.get_template('assignment.cpp')
 

--- a/raco/language/grappa_templates/groupby/0key_output.cpp
+++ b/raco/language/grappa_templates/groupby/0key_output.cpp
@@ -1,3 +1,4 @@
+{{comment}}
 auto {{output_tuple_name}}_tmp = reduce<{% block templateargs %}{% endblock %}>({{hashname}});
 
 {% block output %}{% endblock %}

--- a/raco/language/grappa_templates/groupby/nkey_update.cpp
+++ b/raco/language/grappa_templates/groupby/nkey_update.cpp
@@ -1,1 +1,2 @@
+{{comment}}
 {{hashname}}->update<&{{pipeline_sync}}, {{input_type}}, &{{update_func}},&{{init_func}}>(std::make_tuple({{ keygets|join(',') }}), {{update_val}});

--- a/raco/language/grappa_templates/groupby/scan.cpp
+++ b/raco/language/grappa_templates/groupby/scan.cpp
@@ -1,3 +1,4 @@
+{{comment}}
 {{hashname}}->forall_entries<&{{pipeline_sync}}>([=](std::pair<const {{keytype}},{{emit_type}}>&{{mapping_var_name}}) {
     {{output_tuple_type}} {{output_tuple_name}}({% block initializer %}{{mapping_var_name}}.first{% endblock %});
     {{inner_code}}

--- a/raco/language/grappa_templates/hashjoin/insert_materialize.cpp
+++ b/raco/language/grappa_templates/hashjoin/insert_materialize.cpp
@@ -1,1 +1,2 @@
+{{comment}}
 {{hashname}}.insert_async<&{{pipeline_sync}}>({{keyval}}, {{keyname}});

--- a/raco/language/grappa_templates/hashjoin/lookup.cpp
+++ b/raco/language/grappa_templates/hashjoin/lookup.cpp
@@ -1,3 +1,4 @@
+{{comment}}
 {{hashname}}.lookup_iter<&{{pipeline_sync}}>( {{keyval}}, [=]({{right_tuple_type}}& {{right_tuple_name}}) {
   join_coarse_result_count++;
   {{out_tuple_type}} {{out_tuple_name}} = {{append_func_name}}({{keyname}}, {{right_tuple_name}});

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -719,6 +719,7 @@ class GrappaGroupBy(clangcommon.BaseCGroupby, GrappaOperator):
         state.addDeclarations([output_tuple.generateDefinition()])
 
         inner_code = self.parent().consume(output_tuple, self, state)
+        comment = self.language().comment("scan of " + str(self))
         code = produce_template.render(locals())
         state.setPipelineProperty("type", "in_memory")
         state.addPipeline(code)
@@ -838,6 +839,8 @@ class GrappaGroupBy(clangcommon.BaseCGroupby, GrappaOperator):
 
         update_func = self.update_func
 
+        comment = self.language().comment("insert of " + str(self))
+
         code = materialize_template.render(locals())
         return code
 
@@ -926,6 +929,7 @@ class GrappaHashJoin(GrappaJoin, GrappaOperator):
 
     def consume(self, t, src, state):
         if src.childtag == "right":
+            comment = self.language().comment("right side of " + str(self))
             right_template = self._cgenv.get_template('insert_materialize.cpp')
 
             hashname = self._hashname
@@ -947,6 +951,7 @@ class GrappaHashJoin(GrappaJoin, GrappaOperator):
             return code
 
         if src.childtag == "left":
+            comment = self.language().comment("left side of " + str(self))
             left_template = self._cgenv.get_template('lookup.cpp')
 
             # add a dependence on the right pipeline


### PR DESCRIPTION
e.g.
```c
group_hash_000->forall_entries<&V17>([=](std::pair<const std::tuple<int64_t>,int64_t>&V16) {
    MaterializedTupleRef_V18_0_1 t_008(std::tuple_cat(V16.first, std::make_tuple(V16.second)));
    // GrappaApply(_COLUMN0_=$1,b1=$0)
MaterializedTupleRef_V5_0_1 t_002;t_002.f0 = t_008.f1;
t_002.f1 = t_008.f0;
// left side of GrappaHashJoin(($1 = $2))[GrappaApply(_COLUMN0_=$1,b1=$0)[GrappaGroupBy($1; SUM($0))[GrappaApply(a=$0,b1=$1)[GrappaApply(a=$0,b1=$3)[GrappaHashJoin(($1 = $2))[GrappaMemoryScan[GrappaFileScan(public:adhoc:R2)],GrappaMemoryScan[GrappaFileScan(public:adhoc:T2)]]]]]],GrappaMemoryScan[GrappaFileScan(public:adhoc:S2)]]

hash_000.lookup_iter<&V17>( std::make_tuple(t_002.f1), [=](MaterializedTupleRef_V3_0_1& V19) {
  join_coarse_result_count++;
  MaterializedTupleRef_V20_0_1_2_3 t_009 = create_V21(t_002, V19);
  // GrappaApply(_COLUMN0_=$0,b=$3)
MaterializedTupleRef_V1_0_1 t_000;t_000.f0 = t_009.f0;
t_000.f1 = t_009.f3;
result.push_back(t_000);
VLOG(2) << t_000;
```