### PR TITLE
add a way to pass kwargs to the Raco compiler

### DIFF
--- a/c_test_environment/grappalang_myrial_tests.py
+++ b/c_test_environment/grappalang_myrial_tests.py
@@ -131,6 +131,10 @@ class MyriaLGrappaTest(MyriaLPlatformTestHarness, MyriaLPlatformTests):
         STORE(J, OUTPUT);
         """, "three_way_three_key_hash_join")
 
+    def test_symmetric_array_repr(self):
+        q = self.myrial_from_sql(['T1'], "select")
+        self.check(q, "select", scan_array_repr='symmetric_array')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/raco/language/grappa_templates/symmetric_array_file_scan.cpp
+++ b/raco/language/grappa_templates/symmetric_array_file_scan.cpp
@@ -1,0 +1,10 @@
+if (FLAGS_bin) {
+BinaryRelationFileReader<{{result_type}},
+                           aligned_vector<{{result_type}}>,
+                           SymmetricArrayRepresentation<{{result_type}}>> reader;
+                           {{resultsym}} = reader.read( FLAGS_input_file_{{name}} + ".bin" );
+                           } else {
+
+                           CHECK(false) << "only --bin=true supported for symmetric array repr"
+
+                           }

--- a/raco/language/grappa_templates/symmetric_array_file_scan.cpp
+++ b/raco/language/grappa_templates/symmetric_array_file_scan.cpp
@@ -5,6 +5,6 @@ BinaryRelationFileReader<{{result_type}},
                            {{resultsym}} = reader.read( FLAGS_input_file_{{name}} + ".bin" );
                            } else {
 
-                           CHECK(false) << "only --bin=true supported for symmetric array repr"
+                           CHECK(false) << "only --bin=true supported for symmetric array repr";
 
                            }

--- a/raco/platform_tests.py
+++ b/raco/platform_tests.py
@@ -228,11 +228,8 @@ class MyriaLPlatformTests(object):
         """, "scan")
 
     def test_select(self):
-        self.check_sub_tables("""
-        T1 = SCAN(%(T1)s);
-        x = [FROM T1 WHERE a>5 EMIT a];
-        STORE(x, OUTPUT);
-        """, "select")
+        q = self.myrial_from_sql(['T1'], "select")
+        self.check(q, "select")
 
     def test_join(self):
         self.check_sub_tables("""

--- a/scripts/myrial
+++ b/scripts/myrial
@@ -69,6 +69,8 @@ def parse_options(args):
                        help='Turn on verbose DEBUG logging')
     arg_parser.add_argument('--catalog', dest="catalog_path", default=None, help="[Optional] path to catalog file")
     arg_parser.add_argument('--plan', dest="from_repr", action='store_true', help="[Optional] input file is a plan as a python repr")
+    arg_parser.add_argument('--key', action='append', help="May use this argument multiple times to specify additional arguments to compiler")
+    arg_parser.add_argument('--value', action='append', help="May use this argument multiple times to specify additional arguments to compiler")
     arg_parser.add_argument('file',
                             help='File containing MyriaL source program (or a physical plan if using --plan)')
 
@@ -78,6 +80,12 @@ def parse_options(args):
 
 def main(args):
     opt = parse_options(args)
+
+    if opt.key is not None:
+        assert opt.value is not None and len(opt.key)==len(opt.value), "Must be --key K --value V pairs"
+        kwargs = dict(zip(opt.key, opt.value))
+    else:
+        kwargs = {}
 
     if opt.verbose:
         logging.basicConfig(level=logging.DEBUG)
@@ -133,30 +141,32 @@ def main(args):
             ppj = pd.get_json()
             print(json.dumps(ppj))
         elif opt.standalone:
-            pp = pd.get_physical_plan()
+            pp = pd.get_physical_plan(**kwargs)
             db = FakeDatabase()
             db.evaluate(pp)
         elif opt.repr:
-            pp = pd.get_physical_plan()
+            pp = pd.get_physical_plan(**kwargs)
             print repr(pp)
         elif opt.opt_logical:
             if opt.from_repr:
                 raise "Options opt_logical and --plan are incompatible"
             print_pretty_plan(processor.get_physical_plan(
-                target_alg=OptLogicalAlgebra()))
+                target_alg=OptLogicalAlgebra(), **kwargs))
         elif opt.clang:
-            pp = pd.get_physical_plan(target_alg=GrappaAlgebra())
+            # some useful kwargs
+            # scan_array_repr='symmetric_array'
+            pp = pd.get_physical_plan(target_alg=GrappaAlgebra(), **kwargs)
             print_pretty_plan(pp)
             c = compile(pp)
             fname = '{0}.cpp'.format(os.path.splitext(os.path.basename(opt.file))[0])
             with open(fname, 'w') as f:
                 f.write(c)
         elif opt.sparql:
-            pp = pd.get_physical_plan(target_alg=SPARQLAlgebra())
+            pp = pd.get_physical_plan(target_alg=SPARQLAlgebra(), **kwargs)
             c = compile(pp)
             print c
         else:
-            print_pretty_plan(pd.get_physical_plan())
+            print_pretty_plan(pd.get_physical_plan(**kwargs))
 
     return 0
 
@@ -173,14 +183,15 @@ class PhysicalPlanDispatch(object):
         else:
             raise "Requires processor or repr plan input"
 
-    def get_physical_plan(self, target_alg=None):
+    def get_physical_plan(self, target_alg=None, **kwargs):
         if self.with_repr:
             return from_repr.plan_from_repr(self.with_repr)
         else:
             if target_alg is None:
-                return self.processor.get_physical_plan()
+                return self.processor.get_physical_plan(**kwargs)
             else:
-                return self.processor.get_physical_plan(target_alg=target_alg)
+                return self.processor.get_physical_plan(target_alg=target_alg,
+                                                        **kwargs)
 
     def get_json(self):
         if self.with_repr:


### PR DESCRIPTION
example:
```bash
scripts/myrial -c --catalog=examples/catalog.py examples/join.myl --key=scan_array_repr --value=symmetric_array
```