### PR TITLE
Iterators based code generation

### DIFF
--- a/c_test_environment/grappalang_myrial_tests.py
+++ b/c_test_environment/grappalang_myrial_tests.py
@@ -54,7 +54,7 @@ class MyriaLGrappaTest(MyriaLPlatformTestHarness, MyriaLPlatformTests):
             dwf.write(physical_dot)
 
         # generate code in the target language
-        code = compile(plan)
+        code = compile(plan, **kwargs)
 
         fname = os.path.join("c_test_environment", "{gname}.cpp".format(gname=gname))
         if os.path.exists(fname):

--- a/raco/compile.py
+++ b/raco/compile.py
@@ -64,7 +64,7 @@ def optimize(expr, target, **kwargs):
     return optimize_by_rules(expr, target.opt_rules(**kwargs))
 
 
-def compile(expr):
+def compile(expr, **kwargs):
     """Compile physical plan to linearized form for execution"""
     # TODO: Fix this
     algebra.reset()
@@ -83,7 +83,7 @@ def compile(expr):
     lang = store_expr.language()
 
     if isinstance(store_expr, Pipelined):
-        body = lang.body(store_expr.compilePipeline())
+        body = lang.body(store_expr.compilePipeline(**kwargs))
     else:
         body = lang.body(store_expr)
 

--- a/raco/language/grappa_templates/base_query.cpp
+++ b/raco/language/grappa_templates/base_query.cpp
@@ -27,6 +27,9 @@ using namespace Grappa;
 #include "dates.h"
 #include "relation.hpp"
 
+//FIXME: prefer to include this only for Iterator codes
+#include "Operators.hpp"
+
 DEFINE_uint64( nt, 30, "hack: number of tuples");
 DEFINE_bool( jsonsplits, false, "interpret input file F as F/part-*,"
                              "and containing json records");

--- a/raco/language/grappa_templates/iterators/0key_groupby_source.cpp
+++ b/raco/language/grappa_templates/iterators/0key_groupby_source.cpp
@@ -1,7 +1,7 @@
 class {{class_symbol}} : public ZeroKeyAggregateSource<{{produce_type}}, {{state_type}}, {{combine_func}}> {
     using ZeroKeyAggregateSource<{{produce_type}}, {{state_type}}, {{combine_func}}>::ZeroKeyAggregateSource;
     protected:
-        void mktuple({{produce_type}}& dest, {{state_type}}& src) {
+        void mktuple({{produce_type}}& {{output_tuple}}, {{state_type}}& {{output_typle}}_tmp) {
             {{assignment_code}}
         }
 

--- a/raco/language/grappa_templates/iterators/0key_groupby_source.cpp
+++ b/raco/language/grappa_templates/iterators/0key_groupby_source.cpp
@@ -1,0 +1,8 @@
+class {{class_symbol}} : public ZeroKeyAggregateSource<{{produce_type}}, {{state_type}}, {{combine_func}}> {
+    using ZeroKeyAggregateSource<{{produce_type}}, {{state_type}}, {{combine_func}}>::ZeroKeyAggregateSource;
+    protected:
+        void mktuple({{produce_type}}& dest, {{state_type}}& src) {
+            {{assignment_code}}
+        }
+
+};

--- a/raco/language/grappa_templates/iterators/0key_groupby_source.cpp
+++ b/raco/language/grappa_templates/iterators/0key_groupby_source.cpp
@@ -1,4 +1,4 @@
-class {{class_symbol}} : public ZeroKeyAggregateSource<{{produce_type}}, {{state_type}}, {{combine_func}}> {
+class {{class_symbol}} : public ZeroKeyAggregateSource<{{produce_type}}, {{state_type}}, &{{combine_func}}> {
     using ZeroKeyAggregateSource<{{produce_type}}, {{state_type}}, {{combine_func}}>::ZeroKeyAggregateSource;
     protected:
         void mktuple({{produce_type}}& {{produce_tuple_name}}, {{state_type}}& {{state_tuple_name}}) {

--- a/raco/language/grappa_templates/iterators/0key_groupby_source.cpp
+++ b/raco/language/grappa_templates/iterators/0key_groupby_source.cpp
@@ -1,7 +1,7 @@
 class {{class_symbol}} : public ZeroKeyAggregateSource<{{produce_type}}, {{state_type}}, {{combine_func}}> {
     using ZeroKeyAggregateSource<{{produce_type}}, {{state_type}}, {{combine_func}}>::ZeroKeyAggregateSource;
     protected:
-        void mktuple({{produce_type}}& {{output_tuple}}, {{state_type}}& {{output_typle}}_tmp) {
+        void mktuple({{produce_type}}& {{produce_tuple_name}}, {{state_type}}& {{state_tuple_name}}) {
             {{assignment_code}}
         }
 

--- a/raco/language/grappa_templates/iterators/apply.cpp
+++ b/raco/language/grappa_templates/iterators/apply.cpp
@@ -1,0 +1,7 @@
+class {{class_symbol}} : public Apply<{{consume_type}}, {{produce_type}}> {
+    using Apply<{{consume_type}}, {{produce_type}}>::Apply;
+    protected:
+      void apply({{produce_type}}& {{produce_tuple_name}}, {{consume_type}}& {{consume_tuple_name}}) {
+        {{statements}}
+      }
+};

--- a/raco/language/grappa_templates/iterators/broadcast_stream.cpp
+++ b/raco/language/grappa_templates/iterators/broadcast_stream.cpp
@@ -1,0 +1,7 @@
+class {{class_symbol}} : public BroadcastTupleStream<{left_type}, {right_type}, {output_type}> {
+    using BroadcastTupleStream<{left_type}, {right_type}, {output_type}>::BroadcastTupleStream;
+    protected:
+        void mktuple({output_type}& {output_name}, {left_type}& l, {right_type}& r) {
+              {output_name} = {append_func_name}(l, r);
+        }
+};

--- a/raco/language/grappa_templates/iterators/broadcast_stream.cpp
+++ b/raco/language/grappa_templates/iterators/broadcast_stream.cpp
@@ -1,5 +1,5 @@
 class {{class_symbol}} : public BroadcastTupleStream<{{left_type}}, {{right_type}}, {{output_type}}> {
-    using BroadcastTupleStream<{{left_type}}, {{right_type}, {{output_type}}>::BroadcastTupleStream;
+    using BroadcastTupleStream<{{left_type}}, {{right_type}}, {{output_type}}>::BroadcastTupleStream;
     protected:
         void mktuple({{output_type}}& {{output_name}}, {{left_type}}& l, {{right_type}}& r) {
               {{output_name}} = {{append_func_name}}(l, r);

--- a/raco/language/grappa_templates/iterators/broadcast_stream.cpp
+++ b/raco/language/grappa_templates/iterators/broadcast_stream.cpp
@@ -1,7 +1,7 @@
-class {{class_symbol}} : public BroadcastTupleStream<{left_type}, {right_type}, {output_type}> {
-    using BroadcastTupleStream<{left_type}, {right_type}, {output_type}>::BroadcastTupleStream;
+class {{class_symbol}} : public BroadcastTupleStream<{{left_type}}, {{right_type}}, {{output_type}}> {
+    using BroadcastTupleStream<{{left_type}}, {{right_type}, {{output_type}}>::BroadcastTupleStream;
     protected:
-        void mktuple({output_type}& {output_name}, {left_type}& l, {right_type}& r) {
-              {output_name} = {append_func_name}(l, r);
+        void mktuple({{output_type}}& {{output_name}}, {{left_type}}& l, {{right_type}}& r) {
+              {{output_name}} = {{append_func_name}}(l, r);
         }
 };

--- a/raco/language/grappa_templates/iterators/hashjoin_sink.cpp
+++ b/raco/language/grappa_templates/iterators/hashjoin_sink.cpp
@@ -1,11 +1,11 @@
 class {{class_symbol}} : public HashJoinSink{{side}}<{{keytype}},
                                                      {{left_tuple_type}},
                                                      {{right_tuple_type}},
-                                                     hash_tuple::hash<{{keytype}}>>> {
+                                                     hash_tuple::hash<{{keytype}}>> {
     using HashJoinSink{{side}}<{{keytype}},
                                                      {{left_tuple_type}},
                                                      {{right_tuple_type}},
-                                                     hash_tuple::hash<{{keytype}}>>>::HashJoinSink{{side}};
+                                                     hash_tuple::hash<{{keytype}}>>::HashJoinSink{{side}};
     protected:
       {{keytype}} mktuple({% if side == 'Right' %}
                                       {{right_tuple_type}}

--- a/raco/language/grappa_templates/iterators/hashjoin_sink.cpp
+++ b/raco/language/grappa_templates/iterators/hashjoin_sink.cpp
@@ -1,0 +1,20 @@
+class {{class_symbol}} : public HashJoinSink{{side}}<{{keytype}},
+                                                     {{left_tuple_type}},
+                                                     {{right_tuple_type}},
+                                                     hash_tuple::hash<{{keytype}}>>> {
+    using HashJoinSink{{side}}<{{keytype}},
+                                                     {{left_tuple_type}},
+                                                     {{right_tuple_type}},
+                                                     hash_tuple::hash<{{keytype}}>>>::HashJoinSink{{side}};
+    protected:
+      {{keytype}} mktuple({% if side == 'Right' %}
+                                      {{right_tuple_type}}
+                                      {% else %}
+                                      {{left_tuple_type}}
+                                      {% endif %}
+                                      &{{input_tuple_name}}) {
+
+            return {{keyval}};
+      }
+};
+

--- a/raco/language/grappa_templates/iterators/hashjoin_sink.cpp
+++ b/raco/language/grappa_templates/iterators/hashjoin_sink.cpp
@@ -1,11 +1,11 @@
 class {{class_symbol}} : public HashJoinSink{{side}}<{{keytype}},
                                                      {{left_tuple_type}},
                                                      {{right_tuple_type}},
-                                                     hash_tuple::hash<{{keytype}}>> {
+                                                     hash_tuple::hash<{{keytype}}>, &{{pipeline_sync}}> {
     using HashJoinSink{{side}}<{{keytype}},
                                                      {{left_tuple_type}},
                                                      {{right_tuple_type}},
-                                                     hash_tuple::hash<{{keytype}}>>::HashJoinSink{{side}};
+                                                     hash_tuple::hash<{{keytype}}>, &{{pipeline_sync}}>::HashJoinSink{{side}};
     protected:
       {{keytype}} mktuple({% if side == 'Right' %}
                                       {{right_tuple_type}}

--- a/raco/language/grappa_templates/iterators/hashjoin_source.cpp
+++ b/raco/language/grappa_templates/iterators/hashjoin_source.cpp
@@ -1,13 +1,13 @@
 class {{class_symbol}} : public HashJoinSource<{{keytype}},
                                                 {{left_tuple_type}},
                                                 {{right_tuple_type}},
-                                                hash_tuple::hash<{{keytype}}>>
+                                                hash_tuple::hash<{{keytype}}>,
 {{out_tuple_type}}> {
 
     using HashJoinSource<{{keytype}},
                                                 {{left_tuple_type}},
                                                 {{right_tuple_type}},
-                                                hash_tuple::hash<{{keytype}}>>, {{out_tuple_type}}>::HashJoinSource;
+                                                hash_tuple::hash<{{keytype}}>, {{out_tuple_type}}>::HashJoinSource;
 
     protected:
         {{out_tuple_type}} mktuple({{left_tuple_type}}& {{left_name}}, {{right_tuple_type}}& {{right_name}}) {

--- a/raco/language/grappa_templates/iterators/hashjoin_source.cpp
+++ b/raco/language/grappa_templates/iterators/hashjoin_source.cpp
@@ -1,0 +1,16 @@
+class {{class_symbol}} : public HashJoinSource<{{keytype}},
+                                                {{left_tuple_type}},
+                                                {{right_tuple_type}},
+                                                hash_tuple::hash<{{keytype}}>>
+{{out_tuple_type}}> {
+
+    using HashJoinSource<{{keytype}},
+                                                {{left_tuple_type}},
+                                                {{right_tuple_type}},
+                                                hash_tuple::hash<{{keytype}}>>, {{out_tuple_type}}>::HashJoinSource;
+
+    protected:
+        {{out_tuple_type}} mktuple({{left_tuple_type}}& {{left_name}}, {{right_tuple_type}}& {{right_name}}) {
+            return {{append_func_name}}({{left_name}}, {{right_name}});
+        }
+};

--- a/raco/language/grappa_templates/iterators/instantiate_operator.cpp
+++ b/raco/language/grappa_templates/iterators/instantiate_operator.cpp
@@ -1,0 +1,2 @@
+Operator<{{produce_type}}> * {{symbol}} = new {{call_constructor}};
+

--- a/raco/language/grappa_templates/iterators/instantiate_sink.cpp
+++ b/raco/language/grappa_templates/iterators/instantiate_sink.cpp
@@ -1,0 +1,1 @@
+{{symbol}} = new {{call_constructor}};

--- a/raco/language/grappa_templates/iterators/multikey_groupby_sink.cpp
+++ b/raco/language/grappa_templates/iterators/multikey_groupby_sink.cpp
@@ -1,0 +1,8 @@
+class {{class_symbol}} : public AggregateSink<{{consume_type}}, {{keytype}}, {{state_type}}, &{{pipeline_sync}}> {
+using AggregateSink<{{consume_type}}, {{keytype}}, {{state_type}}, &{{pipeline_sync}}>::AggregateSink;
+protected:
+    {{keytype}} mktuple({{consume_type}}& {{consume_tuple_name}}) {
+        return std::make_tuple({{ keygets|join(',') }})
+    }
+
+};

--- a/raco/language/grappa_templates/iterators/multikey_groupby_sink.cpp
+++ b/raco/language/grappa_templates/iterators/multikey_groupby_sink.cpp
@@ -2,7 +2,7 @@ class {{class_symbol}} : public AggregateSink<{{consume_type}}, {{keytype}}, {{s
 using AggregateSink<{{consume_type}}, {{keytype}}, {{state_type}}, &{{pipeline_sync}}>::AggregateSink;
 protected:
     {{keytype}} mktuple({{consume_type}}& {{consume_tuple_name}}) {
-        return std::make_tuple({{ keygets|join(',') }})
+        return std::make_tuple({{ keygets|join(',') }});
     }
 
 };

--- a/raco/language/grappa_templates/iterators/multikey_groupby_source.cpp
+++ b/raco/language/grappa_templates/iterators/multikey_groupby_source.cpp
@@ -1,0 +1,11 @@
+class {{class_symbol}} : public AggregateSource<{{produce_type}}, {{keytype}}, {{state_type}}, {{input_type}}> {
+    using AggregateSource<{{produce_type}}, {{keytype}}, {{state_type}}, {{input_type}}>::AggregateSource;
+
+    private:
+        typedef AggregateSource<{{produce_type}}, {{keytype}}, {{state_type}}, {{input_type}}>::map_output_t map_output_t;
+
+    protected:
+        void mktuple({{produce_type}}& {{produce_tuple_name}}, map_output_t& {{entry_name}}) {
+            {{assignment_code}}
+        }
+};

--- a/raco/language/grappa_templates/iterators/multikey_groupby_source.cpp
+++ b/raco/language/grappa_templates/iterators/multikey_groupby_source.cpp
@@ -5,7 +5,8 @@ class {{class_symbol}} : public AggregateSource<{{produce_type}}, {{keytype}}, {
         typedef AggregateSource<{{produce_type}}, {{keytype}}, {{state_type}}, {{input_type}}>::map_output_t map_output_t;
 
     protected:
-        void mktuple({{produce_type}}& {{produce_tuple_name}}, map_output_t& {{entry_name}}) {
-            {{assignment_code}}
+        void mktuple({{produce_type}}& {{produce_tuple_name}}, map_output_t& {{mapping_var_name}}) {
+            {{produce_type}} {{produce_tuple_name}}_tmp(std::tuple_cat({{mapping_var_name}}.first, {{mapping_var_name}}.second.to_tuple());
+            {{produce_tuple_name}} = {{produce_tuple_name}}_tmp;
         }
 };

--- a/raco/language/grappa_templates/iterators/multikey_groupby_source.cpp
+++ b/raco/language/grappa_templates/iterators/multikey_groupby_source.cpp
@@ -6,7 +6,7 @@ class {{class_symbol}} : public AggregateSource<{{produce_type}}, {{keytype}}, {
 
     protected:
         void mktuple({{produce_type}}& {{produce_tuple_name}}, map_output_t& {{mapping_var_name}}) {
-            {{produce_type}} {{produce_tuple_name}}_tmp(std::tuple_cat({{mapping_var_name}}.first, {{mapping_var_name}}.second.to_tuple());
+            {{produce_type}} {{produce_tuple_name}}_tmp(std::tuple_cat({{mapping_var_name}}.first, {{mapping_var_name}}.second.to_tuple()));
             {{produce_tuple_name}} = {{produce_tuple_name}}_tmp;
         }
 };

--- a/raco/language/grappa_templates/iterators/partition_groupby/multikey_groupby_sink.cpp
+++ b/raco/language/grappa_templates/iterators/partition_groupby/multikey_groupby_sink.cpp
@@ -1,0 +1,8 @@
+class {{class_symbol}} : public AggregatePartitionSink<{{consume_type}}, {{keytype}}, {{state_type}}> {
+using AggregatePartitionSink<{{consume_type}}, {{keytype}}, {{state_type}}>::AggregatePartitionSink;
+protected:
+    {{keytype}} mktuple({{consume_type}}& {{consume_tuple_name}}) {
+        return std::make_tuple({{ keygets|join(',') }});
+    }
+
+};

--- a/raco/language/grappa_templates/iterators/select.cpp
+++ b/raco/language/grappa_templates/iterators/select.cpp
@@ -1,0 +1,7 @@
+class {{class_symbol}} : public Select<{{consume_type}}, {{produce_type}}> {
+    using Select<{{produce_type}}, {{produce_type}}::Select;
+    protected:
+        bool predicate({{produce_type}} {{consume_tuple_name}}) {
+            return {{expression}}
+        }
+};

--- a/raco/language/grappa_templates/iterators/select.cpp
+++ b/raco/language/grappa_templates/iterators/select.cpp
@@ -1,7 +1,7 @@
 class {{class_symbol}} : public Select<{{consume_type}}, {{produce_type}}> {
     using Select<{{produce_type}}, {{produce_type}}>::Select;
     protected:
-        bool predicate({{produce_type}} {{consume_tuple_name}}) {
+        bool predicate({{produce_type}}& {{consume_tuple_name}}) {
             return {{expression}};
         }
 };

--- a/raco/language/grappa_templates/iterators/select.cpp
+++ b/raco/language/grappa_templates/iterators/select.cpp
@@ -1,5 +1,5 @@
 class {{class_symbol}} : public Select<{{consume_type}}, {{produce_type}}> {
-    using Select<{{produce_type}}, {{produce_type}}::Select;
+    using Select<{{produce_type}}, {{produce_type}}>::Select;
     protected:
         bool predicate({{produce_type}} {{consume_tuple_name}}) {
             return {{expression}}

--- a/raco/language/grappa_templates/iterators/select.cpp
+++ b/raco/language/grappa_templates/iterators/select.cpp
@@ -2,6 +2,6 @@ class {{class_symbol}} : public Select<{{consume_type}}, {{produce_type}}> {
     using Select<{{produce_type}}, {{produce_type}}>::Select;
     protected:
         bool predicate({{produce_type}} {{consume_tuple_name}}) {
-            return {{expression}}
+            return {{expression}};
         }
 };

--- a/raco/language/grappa_templates/iterators/sink_declaration.cpp
+++ b/raco/language/grappa_templates/iterators/sink_declaration.cpp
@@ -1,0 +1,1 @@
+Operator<int> * {{symbol}};

--- a/raco/language/grappa_templates/iterators/withkey_init.cpp
+++ b/raco/language/grappa_templates/iterators/withkey_init.cpp
@@ -1,0 +1,1 @@
+auto {{hashname}} = DHT_symmetric_generic<{{keytype}},{{valtype}},{{update_val_type}},hash_tuple::hash<{{keytype}}>>::create_DHT_symmetric(&{{update_func}}, &{{init_func}});

--- a/raco/language/grappa_templates/symmetric_array_file_scan.cpp
+++ b/raco/language/grappa_templates/symmetric_array_file_scan.cpp
@@ -2,7 +2,13 @@ if (FLAGS_bin) {
 BinaryRelationFileReader<{{result_type}},
                            aligned_vector<{{result_type}}>,
                            SymmetricArrayRepresentation<{{result_type}}>> reader;
-                           {{resultsym}} = reader.read( FLAGS_input_file_{{name}} + ".bin" );
+                           // just always broadcast the name to all cores
+                           // although for some queries it is unnecessary
+                           auto l_{{resultsym}} = reader.read( FLAGS_input_file_{{name}} + ".bin" );
+                           on_all_cores([=] {
+                                {{resultsym}} = l_{{resultsym}};
+                           });
+
                            } else {
 
                            CHECK(false) << "only --bin=true supported for symmetric array repr";

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -1695,8 +1695,8 @@ class IGrappaGroupBy(GrappaGroupBy, Iterator):
             state_type=self.state_tuple.getTupleTypename(),
             input_type = self.input_tuple_type,
             assignment_code=assignment_code,
-            entry_name=output_tuple.name+"_tmp",
-            combine_func=self.func_name
+            mapping_var_name=output_tuple.name+"_entry",
+            combine_func=self.combine_func
         )])
 
         state.addOperator(self.operator_code(
@@ -1745,7 +1745,10 @@ class IGrappaGroupBy(GrappaGroupBy, Iterator):
         symbol = self.declare_sink(state)
         state.addOperator(self.sink_operator_code(
            symbol=symbol,
-           call_constructor="{class_symbol}({inputsym}, {hashname})".format(inputsym=src.symbol, class_symbol=class_symbol, hashname=self._hashname)
+           call_constructor="{class_symbol}({inputsym}, {hashname})".format(
+               inputsym=src.symbol,
+               class_symbol=class_symbol,
+               hashname=self._hashname)
         ))
 
         return None

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -1450,12 +1450,6 @@ class IGrappaStore(GrappaStore, Iterator):
                                                                inputsym=inputsym)
 
     def consume(self, t, src, state):
-        # FIXME hack to include iterators header file
-        # FIXME   I'd prefer to subclass the base_query.cpp template using
-        # FIXME   a jinja block called "includes", but
-        # FIXME   GrappaLanguage.base_template is sort of fixed by _cgenv
-        state.addDeclarations(['#include "Operators.hpp"\n'])
-
         symbol = self.declare_sink(state)
         self._add_result_declaration(t, state)
         state.addOperator(self.sink_operator_code(

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -1653,6 +1653,7 @@ class IGrappaHashJoin(GrappaSymmetricHashJoin, Iterator):
                 right_tuple_type=self.rightTypeRef.getPlaceholder(),
                 input_tuple_name=t.name,
                 keyval=keyval,
+                pipeline_sync=state.getPipelineProperty("global_syncname")
             ), self.right_class_decl])  # add right side here now that left type declared
 
             self.left_syncname = get_pipeline_task_name(state)

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -1454,7 +1454,7 @@ class IGrappaStore(GrappaStore, Iterator):
         # FIXME   I'd prefer to subclass the base_query.cpp template using
         # FIXME   a jinja block called "includes", but
         # FIXME   GrappaLanguage.base_template is sort of fixed by _cgenv
-        state.addDeclarations(["#include Operators.hpp;\n"])
+        state.addDeclarations(['#include "Operators.hpp"\n'])
 
         symbol = self.declare_sink(state)
         self._add_result_declaration(t, state)

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -1676,8 +1676,10 @@ class IGrappaGroupBy(GrappaGroupBy, Iterator):
 
         if self.useKey:
             produce_template = self.iter_cgenv().get_template("multikey_groupby_source.cpp")
+            class_symbol = "AggregateSource_{}".format(gensym())
         else:
             produce_template = self.iter_cgenv().get_template("0key_groupby_source.cpp")
+            class_symbol = "ZeroKeyAggregateSource_{}".format(gensym())
 
         output_tuple = GrappaStagedTupleRef(gensym(), self.scheme())
         state.addDeclarations([output_tuple.generateDefinition()])
@@ -1685,7 +1687,6 @@ class IGrappaGroupBy(GrappaGroupBy, Iterator):
         assignment_code = self._assignment_code(output_tuple)
 
         self.assign_symbol()
-        class_symbol = "AggregateSource_{}".format(gensym())
 
         inp_sch = self.input.scheme()
 

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -1823,7 +1823,7 @@ class IGrappaBroadcastCrossProduct(GrappaBroadcastCrossProduct, Iterator):
             state.addOperator(self.operator_code(
                 produce_type=output.getTupleTypename(),
                 symbol=self.symbol,
-                call_constructor = "{class_symbol}({inputsym}, &{broadcast_tuple}".format(
+                call_constructor = "{class_symbol}({inputsym}, &{broadcast_tuple})".format(
                     class_symbol=class_symbol,
                     broadcast_tuple=self.broadcast_tuple.name,
                     inputsym=src.symbol

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -315,7 +315,7 @@ class GrappaSymmetricHashJoin(GrappaJoin, GrappaOperator):
         return name
 
     def __getHashName__(self):
-        name = "dhash_%s" % self.symBase
+        name = "%s_dhash_%s" % (self.__class__.__name__, self.symBase)
         return name
 
     def __init__(self, *args):
@@ -629,7 +629,7 @@ class GrappaGroupBy(clangcommon.BaseCGroupby, GrappaOperator):
 
     @classmethod
     def __genHashName__(cls):
-        name = "group_hash_%03d" % cls._i
+        name = "%s_hash_%03d" % (cls.__name__, cls._i)
         cls._i += 1
         return name
 

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -1550,7 +1550,8 @@ class IGrappaHashJoin(GrappaSymmetricHashJoin, Iterator):
             keytype = self.__aggregate_type__(self.right.scheme(), self.rightcols)
             state.resolveSymbol(self.rightTypeRef, t.getTupleTypename())
 
-            state.addDeclarations([self.iter_cgenv().get_template("hashjoin_sink.cpp").render(
+            # save to add after left type added
+            self.right_class_decl = self.iter_cgenv().get_template("hashjoin_sink.cpp").render(
                 class_symbol=class_symbol,
                 side=side,
                 keytype=keytype,
@@ -1558,7 +1559,7 @@ class IGrappaHashJoin(GrappaSymmetricHashJoin, Iterator):
                 right_tuple_type=t.getTupleTypename(),
                 input_tuple_name=t.name,
                 keyval=keyval,
-            )])
+            )
 
             self.right_syncname = get_pipeline_task_name(state)
 
@@ -1578,7 +1579,7 @@ class IGrappaHashJoin(GrappaSymmetricHashJoin, Iterator):
                 right_tuple_type=self.rightTypeRef.getPlaceholder(),
                 input_tuple_name=t.name,
                 keyval=keyval,
-            )])
+            ), self.right_class_decl]) # add right here too
 
             self.left_syncname = get_pipeline_task_name(state)
 

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -1579,7 +1579,7 @@ class IGrappaHashJoin(GrappaSymmetricHashJoin, Iterator):
                 right_tuple_type=self.rightTypeRef.getPlaceholder(),
                 input_tuple_name=t.name,
                 keyval=keyval,
-            ), self.right_class_decl]) # add right here too
+            ), self.right_class_decl])  # add right side here now that left type declared
 
             self.left_syncname = get_pipeline_task_name(state)
 

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -1505,35 +1505,37 @@ class IGrappaHashJoin(GrappaSymmetricHashJoin, Iterator):
             side = 'Right'
             class_symbol = class_symbol_template.format(side=side, sym=gensym())
 
+            keyval = self.__aggregate_val__(t, self.rightcols)
+            keytype = self.__aggregate_type__(self.right.scheme(), self.rightcols)
+            state.resolveSymbol(self.rightTypeRef, t.getTupleTypename())
+
             state.addDeclarations([self.iter_cgenv().get_template("hashjoin_sink.cpp").render(
                 class_symbol=class_symbol,
                 side=side,
-                keytype=          None,
-                left_tuple_type=           None,
-                right_tuple_type=           None,
-                input_tuple_name=           None,
-                keyval=           None,
+                keytype=keytype,
+                left_tuple_type=self.leftTypeRef.getPlaceholder(),
+                right_tuple_type=t.getTupleTypename(),
+                input_tuple_name=t.name,
+                keyval=keyval,
             )])
-
-
-            state.resolveSymbol(self.rightTypeRef, "TODO")
 
         elif src.childtag == 'left':
             side = 'Left'
             class_symbol = class_symbol_template.format(side=side, sym=gensym())
 
+            keyval = self.__aggregate_val__(t, self.leftcols)
+            keytype = self.__aggregate_type__(self.left.scheme(), self.leftcols)
+            state.resolveSymbol(self.leftTypeRef, t.getTupleTypename())
+
             state.addDeclarations([self.iter_cgenv().get_template("hashjoin_sink.cpp").render(
                 class_symbol=class_symbol,
                 side=side,
-                keytype=           None,
-                left_tuple_type=           None,
-                right_tuple_type=           None,
-                input_tuple_name=           None,
-                keyval=           None,
+                keytype=keytype,
+                left_tuple_type=t.getTupleTypename(),
+                right_tuple_type=self.rightTypeRef.getPlaceholder(),
+                input_tuple_name=t.name,
+                keyval=keyval,
             )])
-
-
-            state.resolveSymbol(self.leftTypeRef, "TODO")
 
         else:
             assert False, "Invalid child tag: {}".format(src.childtag)

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -1966,7 +1966,7 @@ class CrossProductWithSmall(rules.Rule):
 
     def __str__(self):
         return "CrossProduct(big, singleton) => " \
-               "GrappaBroadcastCrossProduct(big, singleton)"
+               "{}(big, singleton)".format(self.op_class.__name__)
 
 
 class FuseGroupByShuffle(rules.Rule):
@@ -2098,7 +2098,6 @@ class GrappaAlgebra(Algebra):
             rules.push_apply,
             groupby_rules,
             grappify_rules,
-            [CrossProductWithSmall()]
         ]
 
         if SwapJoinSides:

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -1519,7 +1519,14 @@ class GrappaAlgebra(Algebra):
     def __init__(self, emit_print=clangcommon.EMIT_CONSOLE):
         self.emit_print = emit_print
 
-    def opt_rules(self, **kwargs):
+    def opt_rules(self,
+                  join_type=GrappaHashJoin,
+                  scan_array_repr=_ARRAY_REPRESENTATION.GLOBAL_ARRAY,
+                  compiler='push',
+                  SwapJoinSides=False,
+                  external_indexing=False,
+                  **kwargs):
+
         # datalog_rules = [
         # rules.removeProject(),
         #     rules.CrossProduct2Join(),
@@ -1539,17 +1546,12 @@ class GrappaAlgebra(Algebra):
         # rules.FreeMemory()
         # ]
 
-        join_type = kwargs.get('join_type', GrappaHashJoin)
-        scan_array_repr = kwargs.get('scan_array_repr',
-                                     _ARRAY_REPRESENTATION.GLOBAL_ARRAY)
-
-        compiler_type = kwargs.get('compiler', 'push')
-        if compiler_type == 'push':
+        if compiler == 'push':
             grappify_rules = grappify(join_type, self.emit_print, scan_array_repr)
-        elif compiler_type == 'iterator':
+        elif compiler == 'iterator':
             grappify_rules = iteratorfy(self.emit_print, scan_array_repr)
         else:
-            raise ValueError("unsupported argument compiler={0}".format(compiler_type))
+            raise ValueError("unsupported argument compiler={0}".format(compiler))
 
         # sequence that works for myrial
         rule_grps_sequence = [
@@ -1562,11 +1564,11 @@ class GrappaAlgebra(Algebra):
             [CrossProductWithSmall()],
         ]
 
-        if kwargs.get('SwapJoinSides'):
+        if SwapJoinSides:
             rule_grps_sequence.insert(0, [rules.SwapJoinSides()])
 
         # set external indexing on (replacing strings with ints)
-        if kwargs.get('external_indexing'):
+        if external_indexing:
             CBaseLanguage.set_external_indexing(True)
 
         # flatten the rules lists

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -1383,6 +1383,15 @@ class GrappaBroadcastCrossProduct(algebra.CrossProduct, GrappaOperator):
         self.left.childtag = "left"
         self.left.produce(state)
 
+    def _declare_broadcast_tuple(self, t, state):
+        # declare global var and broadcast value
+        self.broadcast_tuple = t.copy_type()
+        var_decl = self.language().cgenv().get_template('tuple_declaration.cpp').render(
+            dst_type_name=self.broadcast_tuple.getTupleTypename(),
+            dst_name=self.broadcast_tuple.name
+        )
+        state.addDeclarations([var_decl])
+
     def consume(self, t, src, state):
         if src.childtag == "right":
             # right to left dependency
@@ -1390,13 +1399,7 @@ class GrappaBroadcastCrossProduct(algebra.CrossProduct, GrappaOperator):
 
             code = self.language().comment(self.shortStr() + " RIGHT")
 
-            # declare global var and broadcast value
-            self.broadcast_tuple = t.copy_type()
-            var_decl = self.language().cgenv().get_template('tuple_declaration.cpp').render(
-                dst_type_name=self.broadcast_tuple.getTupleTypename(),
-                dst_name=self.broadcast_tuple.name
-            )
-            state.addDeclarations([var_decl])
+            self._declare_broadcast_tuple(t, state)
 
             code += """on_all_cores([=] {{
                   {global_name} = {input_name};

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -1632,6 +1632,7 @@ class IGrappaHashJoin(GrappaSymmetricHashJoin, Iterator):
                 right_tuple_type=t.getTupleTypename(),
                 input_tuple_name=t.name,
                 keyval=keyval,
+                pipeline_sync=state.getPipelineProperty("global_syncname")
             )
 
             self.right_syncname = get_pipeline_task_name(state)

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -1698,7 +1698,8 @@ class IGrappaGroupBy(GrappaGroupBy, Iterator):
             input_type = self.input_tuple_type,
             assignment_code=assignment_code,
             mapping_var_name=output_tuple.name+"_entry",
-            combine_func=self.combine_func
+            combine_func=self.combine_func,
+            state_tuple_name=output_tuple.name+"_tmp"
         )])
 
         state.addOperator(self.operator_code(

--- a/raco/pipelines.py
+++ b/raco/pipelines.py
@@ -320,12 +320,12 @@ class Pipelined(object):
         """Denotation for consuming a tuple"""
         return
 
-    def compilePipeline(self, **kwargs):
+    def compilePipeline(self, compiler='push', **kwargs):
         self.__markAllParents__()
 
         compilerstate = {'push': CompileState,
                  'iterator': IteratorCompileState
-        }[kwargs.get('compiler', 'push')]
+        }[compiler]
         state = compilerstate(self.language())
 
         state.addCode(

--- a/raco/pipelines.py
+++ b/raco/pipelines.py
@@ -30,6 +30,7 @@ class ResolvingSymbol:
         # inefficient multi-string replacement
         # TODO: replace with multi-pattern sed script
         for name, val in symbols.items():
+            assert val is not None, "Unresolved symbol: {}".format(name)
             pat = r'{0}{1}'.format(cls._unique_tag, name)
             code = re.sub(pat, val, code)
         return code

--- a/raco/pipelines.py
+++ b/raco/pipelines.py
@@ -283,7 +283,7 @@ class Pipelined(object):
         # Ensure this class follows cooperative multiple inheritance
         super(Pipelined, self).__init__(*args)
 
-    def _markAllParents(self, test_mode=False):
+    def _markAllParents(self, test_mode=False, **kwargs):
         root = self
 
         def markChildParent(op):

--- a/raco/platform_tests.py
+++ b/raco/platform_tests.py
@@ -643,6 +643,17 @@ class MyriaLPlatformTests(object):
         STORE(out2, OUTPUT);
         """, "join", compiler='iterator')
 
+    def test_iterator_aggregate_sum(self):
+        q = self.myrial_from_sql(["R1"], "aggregate_sum")
+        self.check(q, "aggregate_sum", compiler='iterator')
+
+    def test_iterator_aggregate_count_group_one(self):
+        self.check_sub_tables("""
+        R2 = SCAN(%(R2)s);
+        out = [FROM R2 EMIT b, COUNT(a)];
+        STORE(out, OUTPUT);
+        """, "aggregate_count_group_one", compiler='iterator')
+
     def test_symmetric_hash_join(self):
         self.check_sub_tables("""
         R2 = SCAN(%(R2)s);

--- a/raco/platform_tests.py
+++ b/raco/platform_tests.py
@@ -626,6 +626,23 @@ class MyriaLPlatformTests(object):
         q = self.myrial_from_sql(['T1'], "select")
         self.check(q, "select", compiler='iterator')
 
+    def test_iterator_apply(self):
+        self.check_sub_tables("""
+        T2 = SCAN(%(T2)s);
+        interm = [FROM T2 EMIT $0, $1];
+        out = [FROM interm EMIT $1];
+        STORE(out, OUTPUT);
+        """, "apply", compiler='iterator')
+
+    def test_iterator_join(self):
+        self.check_sub_tables("""
+        T3 = SCAN(%(T3)s);
+        R3 = SCAN(%(R3)s);
+        out = JOIN(T3, b, R3, b);
+        out2 = [FROM out WHERE $3 = $5 EMIT $0, $3];
+        STORE(out2, OUTPUT);
+        """, "join", compiler='iterator')
+
     def test_symmetric_hash_join(self):
         self.check_sub_tables("""
         R2 = SCAN(%(R2)s);

--- a/raco/platform_tests.py
+++ b/raco/platform_tests.py
@@ -622,6 +622,10 @@ class MyriaLPlatformTests(object):
                               no_MergeSelects=True,
                               no_PushSelects=True)
 
+    def test_iterator_select(self):
+        q = self.myrial_from_sql(['T1'], "select")
+        self.check(q, "select", compiler='iterator')
+
     def test_symmetric_hash_join(self):
         self.check_sub_tables("""
         R2 = SCAN(%(R2)s);

--- a/scripts/myrial
+++ b/scripts/myrial
@@ -155,9 +155,10 @@ def main(args):
         elif opt.clang:
             # some useful kwargs
             # scan_array_repr='symmetric_array'
-            pp = pd.get_physical_plan(target_alg=GrappaAlgebra(), **kwargs)
+            pp = pd.get_physical_plan(target_alg=GrappaAlgebra(),
+                                      **kwargs)
             print_pretty_plan(pp)
-            c = compile(pp)
+            c = compile(pp, **kwargs)
             fname = '{0}.cpp'.format(os.path.splitext(os.path.basename(opt.file))[0])
             with open(fname, 'w') as f:
                 f.write(c)


### PR DESCRIPTION
Another code generation strategy. Instead of push-based code, generate iterators. These changes pair with `Operators.hpp` in https://github.com/uwsampa/grappa/commit/0dced7cb2f9dda8022f67bfeaa5b2a9828733bec.
Much of the iterator code is there, but we generate subclasses that implement the particular expressions and tuple extraction.