### PR TITLE
proposed design for partitioning info in Raco

### DIFF
--- a/raco/algebra.py
+++ b/raco/algebra.py
@@ -387,7 +387,7 @@ class IdenticalSchemeBinaryOperator(BinaryOperator):
 
     def partitioning(self):
         """keep the partitioning if both sides are identically partitioned"""
-        lp = self.left.partitioning().hash_partitioned
+        lp = self.left.partitioning()
         if lp.hash_partitioned == self.right.partitioning().hash_partitioned:
             return lp
         else:

--- a/raco/algebra.py
+++ b/raco/algebra.py
@@ -663,7 +663,7 @@ class Apply(UnaryOperator):
         # find the emitters $i = Identity($k)
         simple_equals = [expr
                          for expr
-                         in enumerate(self.get_unnamed_emit_exprs())
+                         in self.get_unnamed_emit_exprs()
                          if isinstance(expr, expression.UnnamedAttributeRef)]
 
         return project_partitioning(simple_equals, self.input.partitioning())

--- a/raco/algebra.py
+++ b/raco/algebra.py
@@ -354,7 +354,7 @@ class NaryJoin(NaryOperator):
     def partitioning(self):
         """attributes are mutually exclusive so union the partitioned
         attributes"""
-        attributes = set()
+        attributes = frozenset()
         for c in self.children():
             attributes = attributes.union(c.partitioning().hash_partitioned)
         return RepresentationProperties(hash_partitioned=attributes)
@@ -850,9 +850,8 @@ class Project(UnaryOperator):
         """
         if all partition columns are still present then keep partitioning
         """
-        all_columns = set(self.columnlist)
         ip = self.input.partitioning()
-        if ip.hash_partitioned <= all_columns:
+        if ip.hash_partitioned <= frozenset(self.columnlist):
             return ip
         else:
             return RepresentationProperties()
@@ -921,8 +920,7 @@ class GroupBy(UnaryOperator):
 
     def partitioning(self):
         ip = self.input.partitioning()
-        all_groupings = set(self.grouping_list)
-        if ip.hash_partitioned <= all_groupings:
+        if ip.hash_partitioned <= frozenset(self.grouping_list):
             return ip
         else:
             return RepresentationProperties()
@@ -1049,7 +1047,7 @@ class ProjectingJoin(Join):
     def partitioning(self):
         """Partitioning of a Join followed by a Project"""
         joinp = super(ProjectingJoin, self).partitioning()
-        if joinp <= set(self.output_columns):
+        if joinp <= frozenset(self.output_columns):
             return joinp
         else:
             return RepresentationProperties()
@@ -1101,7 +1099,7 @@ class Shuffle(UnaryOperator):
         if self.shuffle_type == self.ShuffleType.SingleFieldHash \
                 or self.shuffle_type == self.ShuffleType.MultiFieldHash:
             return RepresentationProperties(
-                hash_partitioned=set(
+                hash_partitioned=frozenset(
                     self.columnlist))
         else:
             return RepresentationProperties()
@@ -1226,7 +1224,7 @@ class PartitionBy(UnaryOperator):
         return self.input.num_tuples()
 
     def partitioning(self):
-        return RepresentationProperties(hash_partitioned=set(self.columnlist))
+        return RepresentationProperties(hash_partitioned=frozenset(self.columnlist))
 
     def shortStr(self):
         return "%s(%s)" % (self.opname(), real_str(self.columnlist,

--- a/raco/algebra.py
+++ b/raco/algebra.py
@@ -381,7 +381,7 @@ class NaryJoin(NaryOperator):
 """Logical Relational Algebra"""
 
 
-class SymmetricBinaryOperator(object):
+class IdenticalSchemeBinaryOperator(object):
     """BinaryOperator where both sides have the same schema"""
 
     def partitioning(self):
@@ -393,10 +393,13 @@ class SymmetricBinaryOperator(object):
     def scheme(self):
         """Same semantics as SQL: Assume first schema "wins" and throw an
         error if they don't match during evaluation"""
-        return self.left.scheme()
+        left_sch = self.left.scheme()
+        right_sch = self.right.scheme()
+        assert left_sch == right_sch, "Left and right not the same scheme"
+        return left_sch
 
 
-class Union(SymmetricBinaryOperator):
+class Union(IdenticalSchemeBinaryOperator):
 
     """Set union."""
 
@@ -411,7 +414,7 @@ class Union(SymmetricBinaryOperator):
         return self.opname()
 
 
-class UnionAll(SymmetricBinaryOperator):
+class UnionAll(IdenticalSchemeBinaryOperator):
 
     """Bag union."""
 
@@ -429,7 +432,7 @@ class UnionAll(SymmetricBinaryOperator):
         return self.opname()
 
 
-class Intersection(SymmetricBinaryOperator):
+class Intersection(IdenticalSchemeBinaryOperator):
 
     """Set intersection."""
 
@@ -443,7 +446,7 @@ class Intersection(SymmetricBinaryOperator):
         return self.opname()
 
 
-class Difference(SymmetricBinaryOperator):
+class Difference(IdenticalSchemeBinaryOperator):
 
     """Set difference"""
 

--- a/raco/algebra.py
+++ b/raco/algebra.py
@@ -400,7 +400,8 @@ class IdenticalSchemeBinaryOperator(BinaryOperator):
         right_sch = self.right.scheme()
         assert all(
             la[1] == ra[1] for la, ra in zip(
-                left_sch, right_sch)), "Must be same scheme types: {left} != {right}".format(
+                left_sch, right_sch)), \
+            "Must be same scheme types: {left} != {right}".format(
             left=left_sch, right=right_sch)
         return left_sch
 
@@ -488,7 +489,8 @@ class CompositeBinaryOperator(BinaryOperator):
                              expression.UnnamedAttributeRef(col1))
 
     def partitioning(self):
-        """ The schemas are mutually exclusive so union the partition attributes"""
+        """ The schemas are mutually exclusive
+        so union the partition attributes"""
         return RepresentationProperties(
             hash_partitioned=set.union(
                 self.left.partitioning().hash_partitioned,

--- a/raco/algebra.py
+++ b/raco/algebra.py
@@ -1,7 +1,7 @@
 from raco import expression
 from raco import scheme
 from raco.utility import Printable, real_str
-from catalog import InterestingProperties
+from catalog import RepresentationProperties
 
 from abc import ABCMeta, abstractmethod
 import copy
@@ -78,7 +78,7 @@ class Operator(Printable):
     def partitioning(self):
         """Return the partitioning of the tuples output by this operator.
         Default implementation returns no information"""
-        return InterestingProperties()
+        return RepresentationProperties()
 
     def postorder(self, f):
         """Postorder traversal, applying a function to each operator.  The
@@ -357,7 +357,7 @@ class NaryJoin(NaryOperator):
         attributes = set()
         for c in self.children():
             attributes.union(c.partitioning().hash_partitioned)
-        return InterestingProperties(hash_partitioned=attributes)
+        return RepresentationProperties(hash_partitioned=attributes)
 
     def scheme(self):
         combined = reduce(operator.add, [c.scheme() for c in self.children()])
@@ -386,7 +386,7 @@ class SymmetricBinaryOperator(object):
 
     def partitioning(self):
         """attributes that are partitioned in both inputs"""
-        return InterestingProperties(hash_partitioned=set.intersection(
+        return RepresentationProperties(hash_partitioned=set.intersection(
             self.left.partitioning().hash_partitioned,
             self.right.partitioning().hash_partitioned))
 
@@ -480,7 +480,7 @@ class CompositeBinaryOperator(BinaryOperator):
 
     def partitioning(self):
         """ The schemas are mutually exclusive so union the partition attributes"""
-        return InterestingProperties(hash_partitioned=set.union(self.left.partitioning(),
+        return RepresentationProperties(hash_partitioned=set.union(self.left.partitioning(),
                                                                 self.right.partition()))
 
     def scheme(self):
@@ -617,7 +617,7 @@ class Apply(UnaryOperator):
 
     def partitioning(self):
         # TODO pass on partitioning for easy cases like renames
-        return InterestingProperties()
+        return RepresentationProperties()
 
     def shortStr(self):
         estrs = ",".join(["%s=%s" % (name, str(ex))
@@ -696,7 +696,7 @@ class StatefulApply(UnaryOperator):
 
     def partitioning(self):
         # TODO pass on partitioning for easy cases like renames
-        return InterestingProperties()
+        return RepresentationProperties()
 
     def copy(self, other):
         """deep copy"""
@@ -835,7 +835,7 @@ class Project(UnaryOperator):
 
     def partitioning(self):
         all_columns = set(self.columnlist)
-        return InterestingProperties(hash_partitioned=set.intersection(
+        return RepresentationProperties(hash_partitioned=set.intersection(
             all_columns,
             self.input.partitioning().hash_partitioned))
 
@@ -903,7 +903,7 @@ class GroupBy(UnaryOperator):
 
     def partitioning(self):
         all_groupings = set(self.grouping_list)
-        return InterestingProperties(hash_partitioned=set.intersection(
+        return RepresentationProperties(hash_partitioned=set.intersection(
             all_groupings,
             self.input.partitioning().hash_partitioned
         ))
@@ -1069,7 +1069,7 @@ class Shuffle(UnaryOperator):
         # TODO: incorporate information about functional dependences
         if self.shuffle_type == self.ShuffleType.SingleFieldHash \
                 or self.shuffle_type == self.ShuffleType.MultiFieldHash:
-            return InterestingProperties(hash_partitioned=set(self.columnlist))
+            return RepresentationProperties(hash_partitioned=set(self.columnlist))
 
     def copy(self, other):
         self.columnlist = other.columnlist
@@ -1129,7 +1129,7 @@ class Collect(UnaryOperator):
 
     def partitioning(self):
         # TODO: implement specific-worker partitioning?
-        return InterestingProperties()
+        return RepresentationProperties()
 
     def shortStr(self):
         return "%s(@%s)" % (self.opname(), self.server)
@@ -1181,7 +1181,7 @@ class PartitionBy(UnaryOperator):
         return self.input.num_tuples()
 
     def partitioning(self):
-        return InterestingProperties(hash_partitioned=set(self.columnlist))
+        return RepresentationProperties(hash_partitioned=set(self.columnlist))
 
     def shortStr(self):
         return "%s(%s)" % (self.opname(), real_str(self.columnlist,
@@ -1402,7 +1402,7 @@ class Scan(ZeroaryOperator):
         if partitioning is not None:
             self._partitioning = partitioning
         else:
-            self._partitioning = InterestingProperties()
+            self._partitioning = RepresentationProperties()
 
         ZeroaryOperator.__init__(self)
 

--- a/raco/algebra.py
+++ b/raco/algebra.py
@@ -1477,15 +1477,16 @@ class Scan(ZeroaryOperator):
         return self._partitioning
 
     def __repr__(self):
-        return "{op}({rk!r}, {sch!r}, {card!r})".format(
+        return "{op}({rk!r}, {sch!r}, {card!r}, {part!r})".format(
             op=self.opname(), rk=self.relation_key, sch=self._scheme,
-            card=self._cardinality)
+            card=self._cardinality, part=self._partitioning)
 
     def copy(self, other):
         """deep copy"""
         self.relation_key = other.relation_key
         self._scheme = other._scheme
         self._cardinality = other._cardinality
+        self._partitioning = other._partitioning
 
         # TODO: need a cleaner and more general way of tracing information
         # through the compilation process for debugging purposes

--- a/raco/algebra.py
+++ b/raco/algebra.py
@@ -492,7 +492,7 @@ class CompositeBinaryOperator(BinaryOperator):
         """ The schemas are mutually exclusive
         so union the partition attributes"""
         return RepresentationProperties(
-            hash_partitioned=set.union(
+            hash_partitioned=frozenset.union(
                 self.left.partitioning().hash_partitioned,
                 self.right.partitioning().hash_partitioned))
 

--- a/raco/catalog.py
+++ b/raco/catalog.py
@@ -1,10 +1,12 @@
 from abc import abstractmethod, ABCMeta
-from raco.algebra import DEFAULT_CARDINALITY
-from raco.relation_key import RelationKey
-from raco.scheme import Scheme
 from ast import literal_eval
 import os
 import json
+
+from raco.algebra import DEFAULT_CARDINALITY
+from raco.representation import RepresentationProperties
+from raco.relation_key import RelationKey
+from raco.scheme import Scheme
 
 
 class Relation(object):
@@ -29,22 +31,6 @@ class ASCIIFile(FileRelation):
     pass
 
 
-class RepresentationProperties(object):
-    def __init__(self, hash_partitioned=set(), sorted=None, grouped=None):
-        """
-        @param hash_partitioned: None or list of AttributeRefs in hash key
-        @param sorted: None or list of (AttributeRefs, ASC/DESC) in sort order
-        @param grouped: None or list of AttributeRefs to group by
-
-        None means that no knowledge about the interesting property is
-        known
-        """
-        self.hash_partitioned = hash_partitioned
-
-        if sorted is not None or grouped is not None:
-            raise NotImplementedError("sorted and grouped not yet supported")
-
-
 class Catalog(object):
     __metaclass__ = ABCMeta
 
@@ -60,11 +46,12 @@ class Catalog(object):
     def num_tuples(self, rel_key):
         """ Return number of tuples of rel_key """
 
-    @abstractmethod
-    def interesting_properties(self, rel_key):
+    def representation_properties(self, rel_key):
         """
         Return interesting properties, like partitioning and sorted
         """
+        # default is to return no information
+        return RepresentationProperties()
 
 
 # Some useful Catalog implementations

--- a/raco/catalog.py
+++ b/raco/catalog.py
@@ -29,6 +29,21 @@ class ASCIIFile(FileRelation):
     pass
 
 
+class InterestingProperties(object):
+    def __init__(self, hash_partitioned=None, sorted=None, grouped=None):
+        """
+        @param hash_partitioned: None or list of AttributeRefs in hash key
+        @param sorted: None or list of (AttributeRefs, ASC/DESC) in sort order
+        @param grouped: None or list of AttributeRefs to group by
+
+        None means that no knowledge about the interesting property is
+        known
+        """
+        self.hash_partitioned = hash_partitioned
+        self.sorted = sorted
+        self.grouped = grouped
+
+
 class Catalog(object):
     __metaclass__ = ABCMeta
 
@@ -43,6 +58,12 @@ class Catalog(object):
     @abstractmethod
     def num_tuples(self, rel_key):
         """ Return number of tuples of rel_key """
+
+    @abstractmethod
+    def interesting_properties(self, rel_key):
+        """
+        Return interesting properties, like partitioning and sorted
+        """
 
 
 # Some useful Catalog implementations

--- a/raco/catalog.py
+++ b/raco/catalog.py
@@ -30,7 +30,7 @@ class ASCIIFile(FileRelation):
 
 
 class InterestingProperties(object):
-    def __init__(self, hash_partitioned=None, sorted=None, grouped=None):
+    def __init__(self, hash_partitioned=set(), sorted=None, grouped=None):
         """
         @param hash_partitioned: None or list of AttributeRefs in hash key
         @param sorted: None or list of (AttributeRefs, ASC/DESC) in sort order
@@ -40,8 +40,9 @@ class InterestingProperties(object):
         known
         """
         self.hash_partitioned = hash_partitioned
-        self.sorted = sorted
-        self.grouped = grouped
+
+        if sorted is not None or grouped is not None:
+            raise NotImplementedError("sorted and grouped not yet supported")
 
 
 class Catalog(object):

--- a/raco/catalog.py
+++ b/raco/catalog.py
@@ -29,7 +29,7 @@ class ASCIIFile(FileRelation):
     pass
 
 
-class InterestingProperties(object):
+class RepresentationProperties(object):
     def __init__(self, hash_partitioned=set(), sorted=None, grouped=None):
         """
         @param hash_partitioned: None or list of AttributeRefs in hash key

--- a/raco/language/clang.py
+++ b/raco/language/clang.py
@@ -129,6 +129,9 @@ class CMemoryScan(algebra.UnaryOperator, CCOperator):
     def shortStr(self):
         return "%s" % (self.opname())
 
+    def partitioning(self):
+        raise NotImplementedError()
+
     def __eq__(self, other):
         """
     For what we are using MemoryScan for, the only use

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -255,6 +255,9 @@ class GrappaMemoryScan(algebra.UnaryOperator, GrappaOperator):
     def shortStr(self):
         return "%s" % (self.opname())
 
+    def partitioning(self):
+        raise NotImplementedError
+
     def __eq__(self, other):
         """
         See important __eq__ notes below

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -256,7 +256,7 @@ class GrappaMemoryScan(algebra.UnaryOperator, GrappaOperator):
         return "%s" % (self.opname())
 
     def partitioning(self):
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def __eq__(self, other):
         """

--- a/raco/language/myrialang.py
+++ b/raco/language/myrialang.py
@@ -839,6 +839,8 @@ class MyriaQueryScan(algebra.ZeroaryOperator, MyriaOperator):
         return self._num_tuples
 
     def partitioning(self):
+        # TODO be less conservative by using the partitioning()
+        # TODO   of the query plan in the rule PushIntoSQL
         return RepresentationProperties()
 
     def shortStr(self):
@@ -1049,7 +1051,7 @@ def check_partition_equality(op, representation):
     @return true if the op has an equal hash partitioning to representation
     """
 
-    p = set([expression.ensure_unnamed(attr) for attr in op.partitioning().hash_partitioned])
+    p = set(expression.ensure_unnamed(attr) for attr in op.partitioning().hash_partitioned)
     return p == representation
 
 

--- a/raco/language/myrialang.py
+++ b/raco/language/myrialang.py
@@ -1109,8 +1109,8 @@ def check_partition_equality(op, representation):
     @return true if the op has an equal hash partitioning to representation
     """
 
-    p = set(expression.ensure_unnamed(attr)
-            for attr in op.partitioning().hash_partitioned)
+    p = frozenset(expression.ensure_unnamed(attr)
+                  for attr in op.partitioning().hash_partitioned)
     return p == representation
 
 

--- a/raco/language/myrialang.py
+++ b/raco/language/myrialang.py
@@ -1110,9 +1110,7 @@ def check_partition_equality(op, representation):
     @return true if the op has an equal hash partitioning to representation
     """
 
-    p = frozenset(expression.ensure_unnamed(attr)
-                  for attr in op.partitioning().hash_partitioned)
-    return p == representation
+    return op.partitioning().hash_partitioned == frozenset(representation)
 
 
 class ShuffleBeforeSetop(rules.Rule):
@@ -1134,6 +1132,9 @@ class ShuffleBeforeSetop(rules.Rule):
         exp.right = shuffle_after(exp.right)
 
         return exp
+
+    def __str__(self):
+        return "Setop => Shuffle(Setop)"
 
 
 class ShuffleBeforeJoin(rules.Rule):
@@ -1172,6 +1173,9 @@ class ShuffleBeforeJoin(rules.Rule):
             return algebra.ProjectingJoin(expr.condition,
                                           new_left, new_right,
                                           expr.output_columns)
+
+    def __str__(self):
+        return "Join => Shuffle(Join)"
 
 
 class HCShuffleBeforeNaryJoin(rules.Rule):

--- a/raco/language/sql/catalog.py
+++ b/raco/language/sql/catalog.py
@@ -11,6 +11,7 @@ from raco.catalog import Catalog
 import raco.expression as expression
 import raco.scheme as scheme
 import raco.types as types
+from raco.representation import RepresentationProperties
 
 
 type_to_raco = {Integer: types.LONG_TYPE,
@@ -43,6 +44,9 @@ class SQLCatalog(Catalog):
         """ Return number of tuples of rel_key """
         table = self.metadata.tables[str(rel_key)]
         return self.engine.execute(table.count()).scalar()
+
+    def partitioning(self, rel_key):
+        return RepresentationProperties()
 
     def get_scheme(self, rel_key):
         table = self.metadata.tables[str(rel_key)]

--- a/raco/myrial/interpreter.py
+++ b/raco/myrial/interpreter.py
@@ -96,7 +96,8 @@ class ExpressionProcessor(object):
         assert isinstance(rel_key, relation_key.RelationKey)
         scheme = self._get_scan_scheme(rel_key)
         return raco.algebra.Scan(rel_key, scheme,
-                                 self.catalog.num_tuples(rel_key))
+                                 self.catalog.num_tuples(rel_key),
+                                 self.catalog.partitioning(rel_key))
 
     def samplescan(self, rel_key, samp_size, is_pct, samp_type):
         """Sample a base relation."""

--- a/raco/myrial/optimizer_tests.py
+++ b/raco/myrial/optimizer_tests.py
@@ -24,8 +24,11 @@ class OptimizerTest(myrial_test.MyrialTestCase):
 
     x_scheme = scheme.Scheme([("a", types.LONG_TYPE), ("b", types.LONG_TYPE), ("c", types.LONG_TYPE)])  # noqa
     y_scheme = scheme.Scheme([("d", types.LONG_TYPE), ("e", types.LONG_TYPE), ("f", types.LONG_TYPE)])  # noqa
+    part_scheme = scheme.Scheme([("g", types.LONG_TYPE), ("h", types.LONG_TYPE), ("i", types.LONG_TYPE)])  # noqa
     x_key = relation_key.RelationKey.from_string("public:adhoc:X")
     y_key = relation_key.RelationKey.from_string("public:adhoc:Y")
+    part_key = relation_key.RelationKey.from_string("public:adhoc:part")
+    part_partition = RepresentationProperties(hash_partitioned=frozenset([AttIndex(1)]))
 
     def setUp(self):
         super(OptimizerTest, self).setUp()
@@ -39,6 +42,9 @@ class OptimizerTest(myrial_test.MyrialTestCase):
         self.y_data = collections.Counter(
             [(random.randrange(rng), random.randrange(rng),
               random.randrange(rng)) for _ in range(count)])
+        self.part_data = collections.Counter(
+            [(random.randrange(rng), random.randrange(rng),
+              random.randrange(rng)) for _ in range(count)])
 
         self.db.ingest(OptimizerTest.x_key,
                        self.x_data,
@@ -46,6 +52,10 @@ class OptimizerTest(myrial_test.MyrialTestCase):
         self.db.ingest(OptimizerTest.y_key,
                        self.y_data,
                        OptimizerTest.y_scheme)
+        self.db.ingest(OptimizerTest.part_key,
+                       self.part_data,
+                       OptimizerTest.part_scheme,
+                       self.part_partition)  # "partitioned" table
 
         self.expected = collections.Counter(
             [(a, b, c, d, e, f) for (a, b, c) in self.x_data
@@ -830,3 +840,43 @@ class OptimizerTest(myrial_test.MyrialTestCase):
             if isinstance(op, Select):
                 self.assertIsInstance(op.input, MyriaSplitConsumer)
                 self.assertIsInstance(op.input.input.input, CrossProduct)
+
+    def test_partitioning_from_shuffle(self):
+        """Store will know the partitioning of a shuffled relation"""
+        query = """
+        r = scan({x});
+        store(r, OUTPUT);
+        """.format(x=self.x_key)
+
+        lp = self.get_logical_plan(query)
+
+        # insert a shuffle
+        tail = lp.args[0].input
+        lp.args[0].input = Shuffle(tail, [AttIndex(0)])
+
+        pp = self.logical_to_physical(lp)
+        self.assertEquals(self.get_count(pp, MyriaShuffleProducer), 1)
+        self.assertEquals(self.get_count(pp, MyriaShuffleConsumer), 1)
+        self.assertEquals(pp.partitioning().hash_partitioned,
+                         frozenset([AttIndex(0)]))
+
+    def test_partitioning_from_scan(self):
+        """Store will know the partitioning of a partitioned store relation"""
+        query = """
+        r = scan({part});
+        store(r, OUTPUT);
+        """.format(part=self.part_key)
+
+        lp = self.get_logical_plan(query)
+        pp = self.logical_to_physical(lp)
+
+        print lp.args[0], lp.args[0].partitioning()
+        print lp.args[0].input, lp.args[0].input.partitioning()
+        print pp, pp.partitioning()
+        print pp.input, pp.input.partitioning()
+        print self.part_partition
+        self.assertEquals(pp.partitioning().hash_partitioned,
+                          self.part_partition.hash_partitioned)
+
+
+

--- a/raco/myrial/optimizer_tests.py
+++ b/raco/myrial/optimizer_tests.py
@@ -1003,4 +1003,3 @@ class OptimizerTest(myrial_test.MyrialTestCase):
         # (in general, info could be h($0) && h($2)
         self.assertEquals(pp.partitioning().hash_partitioned,
                           frozenset([AttIndex(0)]))
-

--- a/raco/representation.py
+++ b/raco/representation.py
@@ -1,0 +1,17 @@
+__author__ = 'brandon'
+
+
+class RepresentationProperties(object):
+    def __init__(self, hash_partitioned=set(), sorted=None, grouped=None):
+        """
+        @param hash_partitioned: None or list of AttributeRefs in hash key
+        @param sorted: None or list of (AttributeRefs, ASC/DESC) in sort order
+        @param grouped: None or list of AttributeRefs to group by
+
+        None means that no knowledge about the interesting property is
+        known
+        """
+        self.hash_partitioned = hash_partitioned
+
+        if sorted is not None or grouped is not None:
+            raise NotImplementedError("sorted and grouped not yet supported")

--- a/raco/representation.py
+++ b/raco/representation.py
@@ -15,3 +15,16 @@ class RepresentationProperties(object):
 
         if sorted is not None or grouped is not None:
             raise NotImplementedError("sorted and grouped not yet supported")
+
+    def __str__(self):
+        return "{clazz}(hash: {hash_attrs})".format(
+            clazz=self.__class__.__name__,
+            hash_attrs=self.hash_partitioned)
+
+    def __repr__(self):
+        return "{clazz}({hp!r}, {sort!r}, {grp!r})".format(
+            clazz=self.__class__.__name__,
+            hp=self.hash_partitioned,
+            sort=None,
+            grp=None
+        )

--- a/raco/representation.py
+++ b/raco/representation.py
@@ -1,17 +1,19 @@
-__author__ = 'brandon'
 
 
 class RepresentationProperties(object):
-    def __init__(self, hash_partitioned=set(), sorted=None, grouped=None):
+    def __init__(self, hash_partitioned=None, sorted=None, grouped=None):
         """
-        @param hash_partitioned: None or list of AttributeRefs in hash key
+        @param hash_partitioned: None or set of AttributeRefs in hash key
         @param sorted: None or list of (AttributeRefs, ASC/DESC) in sort order
         @param grouped: None or list of AttributeRefs to group by
 
         None means that no knowledge about the interesting property is
         known
         """
-        self.hash_partitioned = hash_partitioned
+        if hash_partitioned is None:
+            self.hash_partitioned = set()
+        else:
+            self.hash_partitioned = hash_partitioned
 
         if sorted is not None or grouped is not None:
             raise NotImplementedError("sorted and grouped not yet supported")

--- a/raco/representation.py
+++ b/raco/representation.py
@@ -1,7 +1,12 @@
 
 
 class RepresentationProperties(object):
-    def __init__(self, hash_partitioned=frozenset(), sorted=None, grouped=None):
+
+    def __init__(
+            self,
+            hash_partitioned=frozenset(),
+            sorted=None,
+            grouped=None):
         """
         @param hash_partitioned: None or set of AttributeRefs in hash key
         @param sorted: None or list of (AttributeRefs, ASC/DESC) in sort order
@@ -11,6 +16,10 @@ class RepresentationProperties(object):
         known
         """
 
+        # TODO: make it a set of sets, representing a conjunction of hashes
+        # TODO: for example, after a HashJoin($1=$4) we know h($1) && h($4)
+        # TODO:     which is not equivalent to h($1, $4). Currently can only
+        # TODO:     represent conjunctions of size 1
         self.hash_partitioned = hash_partitioned
 
         if sorted is not None or grouped is not None:

--- a/raco/representation.py
+++ b/raco/representation.py
@@ -1,7 +1,7 @@
 
 
 class RepresentationProperties(object):
-    def __init__(self, hash_partitioned=None, sorted=None, grouped=None):
+    def __init__(self, hash_partitioned=frozenset(), sorted=None, grouped=None):
         """
         @param hash_partitioned: None or set of AttributeRefs in hash key
         @param sorted: None or list of (AttributeRefs, ASC/DESC) in sort order
@@ -10,10 +10,8 @@ class RepresentationProperties(object):
         None means that no knowledge about the interesting property is
         known
         """
-        if hash_partitioned is None:
-            self.hash_partitioned = set()
-        else:
-            self.hash_partitioned = hash_partitioned
+
+        self.hash_partitioned = hash_partitioned
 
         if sorted is not None or grouped is not None:
             raise NotImplementedError("sorted and grouped not yet supported")

--- a/raco/scheme.py
+++ b/raco/scheme.py
@@ -15,33 +15,17 @@ class DummyScheme(object):
         return "DummyScheme()"
 
 
-class InterestingOrders(object):
-    def __init__(self, hash_partitioned=None, sorted=None, grouped=None):
-        """
-        @param hash_partitioned: None or list of AttributeRefs in hash key
-        @param sorted: None or list of (AttributeRefs, ASC/DESC) in sort order
-        @param grouped: None or list of AttributeRefs to group by
-
-        None means that no knowledge about the interesting order is
-        known
-        """
-        self.hash_partitioned = hash_partitioned
-        self.sorted = sorted
-        self.grouped = grouped
-
-
 class Scheme(object):
     """Add an attribute to the scheme."""
     salt = "1"
 
-    def __init__(self, attributes=None, interesting_orders=InterestingOrders()):
+    def __init__(self, attributes=None):
         if attributes is None:
             attributes = []
         self.attributes = []
         self.asdict = OrderedDict()
         for n, t in attributes:
             self.addAttribute(n, t)
-        self.interesting_orders = interesting_orders
 
     def addAttribute(self, name, _type):
         assert _type in raco.types.ALL_TYPES, \
@@ -56,9 +40,6 @@ class Scheme(object):
         self.attributes.append((name, _type))
         # just in case we changed the name.  ugly.
         return name
-
-    def get_iteresting_orders(self):
-        return self.interesting_orders
 
     def get_types(self):
         """Return a list of the types in this scheme."""

--- a/raco/scheme.py
+++ b/raco/scheme.py
@@ -3,8 +3,6 @@ import raco.types
 
 from collections import OrderedDict
 
-from abc import abstractmethod
-
 
 class DummyScheme(object):
     """Dummy scheme used to generate plans in the absence of catalog info."""

--- a/raco/scheme.py
+++ b/raco/scheme.py
@@ -3,6 +3,8 @@ import raco.types
 
 from collections import OrderedDict
 
+from abc import abstractmethod
+
 
 class DummyScheme(object):
     """Dummy scheme used to generate plans in the absence of catalog info."""
@@ -13,17 +15,33 @@ class DummyScheme(object):
         return "DummyScheme()"
 
 
+class InterestingOrders(object):
+    def __init__(self, hash_partitioned=None, sorted=None, grouped=None):
+        """
+        @param hash_partitioned: None or list of AttributeRefs in hash key
+        @param sorted: None or list of (AttributeRefs, ASC/DESC) in sort order
+        @param grouped: None or list of AttributeRefs to group by
+
+        None means that no knowledge about the interesting order is
+        known
+        """
+        self.hash_partitioned = hash_partitioned
+        self.sorted = sorted
+        self.grouped = grouped
+
+
 class Scheme(object):
     """Add an attribute to the scheme."""
     salt = "1"
 
-    def __init__(self, attributes=None):
+    def __init__(self, attributes=None, interesting_orders=InterestingOrders()):
         if attributes is None:
             attributes = []
         self.attributes = []
         self.asdict = OrderedDict()
         for n, t in attributes:
             self.addAttribute(n, t)
+        self.interesting_orders = interesting_orders
 
     def addAttribute(self, name, _type):
         assert _type in raco.types.ALL_TYPES, \
@@ -38,6 +56,9 @@ class Scheme(object):
         self.attributes.append((name, _type))
         # just in case we changed the name.  ugly.
         return name
+
+    def get_iteresting_orders(self):
+        return self.interesting_orders
 
     def get_types(self):
         """Return a list of the types in this scheme."""


### PR DESCRIPTION
Proposing to add interesting orders to the scheme rather than the catalog. The reason is that we would like to track interesting orders at the operator granularity and every operator already has a scheme

__WIP__
- [x] design agreed upon
- [x] @bmyerz make __fake__ catalog create schema with interesting orders
- ~~[ ] @senderista update myria catalog interface to get myria's catalog partition info (note that the myria catalog interface is buried in another unmerged branch https://github.com/uwescience/raco/blob/raco_only_execution/raco/backends/myria/catalog.py part of PR #~450 )~~, moved to #472
- [x] @bmyerz operators propagate partition info from Shuffle/(or radish HashJoin) to store
- ~~[ ] @senderista myriax store `compileme` to json needs to include partitioning info~~, moved to #472
- [x] @bmyerz rule to omit a shuffle when relations are co-partitioned
- [x] tests

We can be conservative, then add more partitioning logic after this PR.

fixes #466 