### PR TITLE
radish decomposed aggregates

### DIFF
--- a/raco/language/grappa_templates/groupby/withkey_decl.cpp
+++ b/raco/language/grappa_templates/groupby/withkey_decl.cpp
@@ -1,0 +1,2 @@
+decltype(DHT_symmetric<{{keytype}},{{valtype}},hash_tuple::hash<{{keytype}}>>::create_DHT_symmetric( )) {{hashname}};
+

--- a/raco/language/grappa_templates/groupby/withkey_init.cpp
+++ b/raco/language/grappa_templates/groupby/withkey_init.cpp
@@ -1,1 +1,4 @@
-auto {{hashname}} = DHT_symmetric<{{keytype}},{{valtype}},hash_tuple::hash<{{keytype}}>>::create_DHT_symmetric( );
+auto l_{{hashname}} = DHT_symmetric<{{keytype}},{{valtype}},hash_tuple::hash<{{keytype}}>>::create_DHT_symmetric( );
+on_all_cores([=] {
+  {{hashname}} = l_{{hashname}};
+});

--- a/raco/language/grappa_templates/partition_groupby/nkey_update.cpp
+++ b/raco/language/grappa_templates/partition_groupby/nkey_update.cpp
@@ -1,2 +1,2 @@
 {{comment}}
-{{hashname}}->update_partition<{{input_type}}, &{{update_func}},&{{init_func}}>(std::make_tuple({{ keygets|join(',') }}), {{update_val}});
+{{hashname}}->template update_partition<{{input_type}}, &{{update_func}},&{{init_func}}>(std::make_tuple({{ keygets|join(',') }}), {{update_val}});

--- a/raco/language/grappa_templates/partition_groupby/nkey_update.cpp
+++ b/raco/language/grappa_templates/partition_groupby/nkey_update.cpp
@@ -1,0 +1,2 @@
+{{comment}}
+{{hashname}}->update_partition<{{input_type}}, &{{update_func}},&{{init_func}}>(std::make_tuple({{ keygets|join(',') }}), {{update_val}});

--- a/raco/language/grappa_templates/shuffle.cpp
+++ b/raco/language/grappa_templates/shuffle.cpp
@@ -1,0 +1,5 @@
+{{comment}}
+auto target = hash_tuple::hash<{{keytype}}>({{keyval}}) % Grappa::cores();
+Grappa::delegate::call<async, &{{pipeline_sync}}>(target, [{{keyname}}] {
+    {{inner_code}}
+});

--- a/raco/language/grappa_templates/shuffle.cpp
+++ b/raco/language/grappa_templates/shuffle.cpp
@@ -1,5 +1,8 @@
 {{comment}}
-auto target = hash_tuple::hash<{{keytype}}>({{keyval}}) % Grappa::cores();
+auto target = hash_tuple::hash<{{keytype}}>()({{keyval}}) % Grappa::cores();
+// DEV NOTE: if something inside this call is not captured in the lambda,
+// (probably a data structure) then we need to change its declaration to a global one.
+// The alternative is just to capture [=] but this will mask unneeded communication.
 Grappa::delegate::call<async, &{{pipeline_sync}}>(target, [{{keyname}}] {
     {{inner_code}}
 });

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -730,6 +730,7 @@ class GrappaGroupBy(clangcommon.BaseCGroupby, GrappaOperator):
         hashname = self._hashname
 
         if self.useKey:
+            decl_template = self._cgenv.get_template('withkey_decl.cpp')
             init_template = self._cgenv.get_template('withkey_init.cpp')
             valtype = state_type
         else:
@@ -743,6 +744,7 @@ class GrappaGroupBy(clangcommon.BaseCGroupby, GrappaOperator):
             # FOR BUILTINs        self.__get_initial_value__(0,
             # cached_inp_sch=inp_sch)
 
+        state.addDeclarations([decl_template.render(locals())])
         state.addInitializers([init_template.render(locals())])
 
         if not hashtableInfo:

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -1514,7 +1514,7 @@ class GrappaAlgebra(Algebra):
         if groupby_sematics == 'global':
             groupby_rules = [rules.OneToOne(algebra.GroupBy, GrappaGroupBy)]
         elif groupby_sematics == 'partition':
-            groupby_rules = rules.distributed_group_by(GrappaPartitionGroupBy, countall_rule=False)
+            groupby_rules = rules.distributed_group_by(GrappaPartitionGroupBy, countall_rule=False, only_fire_on_multi_key=True)
         else:
             raise ValueError("groupby_semantics must be one of {global, partition}")
 

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -1514,7 +1514,7 @@ class GrappaAlgebra(Algebra):
         if groupby_sematics == 'global':
             groupby_rules = [rules.OneToOne(algebra.GroupBy, GrappaGroupBy)]
         elif groupby_sematics == 'partition':
-            groupby_rules = rules.distributed_group_by(GrappaPartitionGroupBy, countall_rule=False, only_fire_on_multi_key=True)
+            groupby_rules = rules.distributed_group_by(GrappaPartitionGroupBy, countall_rule=False, only_fire_on_multi_key=GrappaGroupBy)
         else:
             raise ValueError("groupby_semantics must be one of {global, partition}")
 

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -733,6 +733,7 @@ class GrappaGroupBy(clangcommon.BaseCGroupby, GrappaOperator):
             decl_template = self._cgenv.get_template('withkey_decl.cpp')
             init_template = self._cgenv.get_template('withkey_init.cpp')
             valtype = state_type
+            state.addDeclarations([decl_template.render(locals())])
         else:
             no_key_state_initializer = \
                 "symmetric_global_alloc<{state_tuple_type}>()".format(
@@ -744,7 +745,6 @@ class GrappaGroupBy(clangcommon.BaseCGroupby, GrappaOperator):
             # FOR BUILTINs        self.__get_initial_value__(0,
             # cached_inp_sch=inp_sch)
 
-        state.addDeclarations([decl_template.render(locals())])
         state.addInitializers([init_template.render(locals())])
 
         if not hashtableInfo:

--- a/raco/language/myrialang.py
+++ b/raco/language/myrialang.py
@@ -2,6 +2,7 @@ import itertools
 import logging
 from collections import defaultdict, deque
 from operator import mul
+
 from sqlalchemy.dialects import postgresql
 
 from raco import algebra, expression, rules, scheme
@@ -12,11 +13,9 @@ from raco.language import Language, Algebra
 from raco.language.sql.catalog import SQLCatalog
 from raco.expression import WORKERID, COUNTALL
 from raco.expression import UnnamedAttributeRef
-from raco.expression.aggregate import (rebase_local_aggregate_output,
-                                       rebase_finalizer)
-from raco.expression.statevar import *
 from raco.datastructure.UnionFind import UnionFind
 from raco import types
+from raco.rules import distributed_group_by
 
 LOGGER = logging.getLogger(__name__)
 
@@ -1303,133 +1302,6 @@ class ShuffleAfterSingleton(rules.Rule):
         return expr
 
 
-class DecomposeGroupBy(rules.Rule):
-    """Convert a logical group by into a two-phase group by.
-
-    The local half of the aggregate before the shuffle step, whereas the remote
-    half runs after the shuffle step.
-
-    TODO: omit this optimization if the data is already shuffled, or
-    if the cardinality of the grouping keys is high.
-    """
-
-    @staticmethod
-    def do_transfer(op):
-        """Introduce a network transfer before a groupby operation."""
-
-        # Get an array of position references to columns in the child scheme
-        child_scheme = op.input.scheme()
-        group_fields = [expression.toUnnamed(ref, child_scheme)
-                        for ref in op.grouping_list]
-        if len(group_fields) == 0:
-            # Need to Collect all tuples at once place
-            op.input = algebra.Collect(op.input)
-        else:
-            # Need to Shuffle
-            op.input = algebra.Shuffle(op.input, group_fields)
-
-    def fire(self, op):
-        # Punt if it's not a group by or we've already converted this into an
-        # an instance of MyriaGroupBy
-        if op.__class__ != algebra.GroupBy:
-            return op
-
-        # Bail early if we have any non-decomposable aggregates
-        if not all(x.is_decomposable() for x in op.aggregate_list):
-            out_op = MyriaGroupBy()
-            out_op.copy(op)
-            DecomposeGroupBy.do_transfer(out_op)
-            return out_op
-
-        num_grouping_terms = len(op.grouping_list)
-
-        local_emitters = []
-        local_statemods = []
-        remote_emitters = []
-        remote_statemods = []
-        finalizer_exprs = []
-
-        # The starting positions for the current local, remote aggregate
-        local_output_pos = num_grouping_terms
-        remote_output_pos = num_grouping_terms
-        requires_finalizer = False
-
-        for agg in op.aggregate_list:
-            # Multiple emit arguments can be associated with a single
-            # decomposition rule; coalesce them all together.
-            state = agg.get_decomposable_state()
-            assert state
-
-            ################################
-            # Extract the set of emitters and statemods required for the
-            # local aggregate.
-            ################################
-
-            laggs = state.get_local_emitters()
-            local_emitters.extend(laggs)
-            local_statemods.extend(state.get_local_statemods())
-
-            ################################
-            # Extract the set of emitters and statemods required for the
-            # remote aggregate.  Remote expressions must be rebased to
-            # remove instances of LocalAggregateOutput
-            ################################
-
-            raggs = state.get_remote_emitters()
-            raggs = [rebase_local_aggregate_output(x, local_output_pos)
-                     for x in raggs]
-            remote_emitters.extend(raggs)
-
-            rsms = state.get_remote_statemods()
-            for sm in rsms:
-                update_expr = rebase_local_aggregate_output(
-                    sm.update_expr, local_output_pos)
-                remote_statemods.append(
-                    StateVar(sm.name, sm.init_expr, update_expr))
-
-            ################################
-            # Extract any required finalizers.  These must be rebased to remove
-            # instances of RemoteAggregateOutput
-            ################################
-
-            finalizer = state.get_finalizer()
-            if finalizer is not None:
-                requires_finalizer = True
-                finalizer_exprs.append(
-                    rebase_finalizer(finalizer, remote_output_pos))
-            else:
-                for i in range(len(raggs)):
-                    finalizer_exprs.append(
-                        UnnamedAttributeRef(remote_output_pos + i))
-
-            local_output_pos += len(laggs)
-            remote_output_pos += len(raggs)
-
-        ################################
-        # Glue together the local and remote aggregates:
-        # Local => Shuffle => Remote => (optional) Finalizer.
-        ################################
-
-        local_gb = MyriaGroupBy(op.grouping_list, local_emitters, op.input,
-                                local_statemods)
-
-        grouping_fields = [UnnamedAttributeRef(i)
-                           for i in range(num_grouping_terms)]
-
-        remote_gb = MyriaGroupBy(grouping_fields, remote_emitters, local_gb,
-                                 remote_statemods)
-
-        DecomposeGroupBy.do_transfer(remote_gb)
-
-        if requires_finalizer:
-            # Pass through grouping terms
-            gmappings = [(None, UnnamedAttributeRef(i))
-                         for i in range(num_grouping_terms)]
-            fmappings = [(None, fx) for fx in finalizer_exprs]
-            return algebra.Apply(gmappings + fmappings, remote_gb)
-        return remote_gb
-
-
 class AddAppendTemp(rules.Rule):
     def fire(self, op):
         if type(op) is not MyriaStoreTemp:
@@ -1599,17 +1471,6 @@ left_deep_tree_shuffle_logic = [
     CollectBeforeLimit(),
 ]
 
-# 7. distributed groupby
-# this need to be put after shuffle logic
-distributed_group_by = [
-    # DecomposeGroupBy may introduce a complex GroupBy,
-    # so we must run SimpleGroupBy after it. TODO no one likes this.
-    DecomposeGroupBy(),
-    rules.SimpleGroupBy(),
-    rules.CountToCountall(),   # TODO revisit when we have NULL support.
-    rules.DedupGroupBy(),
-    rules.EmptyGroupByToDistinct(),
-]
 
 # 8. Myriafy logical operators
 # replace logical operator with its corresponding Myria operators
@@ -1682,7 +1543,7 @@ class MyriaLeftDeepTreeAlgebra(MyriaAlgebra):
             rules.push_project,
             rules.push_apply,
             left_deep_tree_shuffle_logic,
-            distributed_group_by,
+            distributed_group_by(MyriaGroupBy),
             [rules.PushApply()],
             [LogicalSampleToDistributedSample()],
         ]

--- a/raco/rules.py
+++ b/raco/rules.py
@@ -805,7 +805,7 @@ class DecomposeGroupBy(Rule):
     if the cardinality of the grouping keys is high.
     """
 
-    def __init__(self, partition_groupby_class, only_fire_on_multi_key=False):
+    def __init__(self, partition_groupby_class, only_fire_on_multi_key=None):
         self._gb_class = partition_groupby_class
         self._only_fire_on_multi_key = only_fire_on_multi_key
         super(DecomposeGroupBy, self).__init__()
@@ -832,7 +832,9 @@ class DecomposeGroupBy(Rule):
             return op
 
         if self._only_fire_on_multi_key and len(op.grouping_list) == 0:
-            return op
+            out_op = self._only_fire_on_multi_key()
+            out_op.copy(op)
+            return out_op
 
         # Bail early if we have any non-decomposable aggregates
         if not all(x.is_decomposable() for x in op.aggregate_list):


### PR DESCRIPTION
fixes #478 

Making Radish support decomposed groupbys was relatively simple. It involved 
- implementing `GrappaShuffle` (the code for which is inside of the implementations of Grappa global hash tables).
- pulling `DecomposeGroupBy` rule out of myrialang to rules.py, where it can be used by any distributed algebra
- implementing `GrappaPartitionGroupBy` as a simple override of some code templates from `GrappaGroupBy`