### PR TITLE
fix performance bug: GRAPPA_BLOCK_ALIGNED too conservative

### DIFF
--- a/raco/language/clangcommon.py
+++ b/raco/language/clangcommon.py
@@ -306,7 +306,7 @@ _cgenv = CBaseLanguage.__get_env_for_template_libraries__()
 # just has relationsymbol and row
 
 
-class StagedTupleRef:
+class StagedTupleRef(object):
     nextid = 0
 
     @staticmethod

--- a/raco/language/clangcommon.py
+++ b/raco/language/clangcommon.py
@@ -574,7 +574,7 @@ class CBaseFileScan(Pipelined, algebra.Scan):
             fstemplate, fsbindings = self.__compileme__(resultsym, name)
             state.saveExpr(self, resultsym)
 
-            stagedTuple = self.new_tuple_ref(resultsym, self.scheme())
+            stagedTuple = self.new_tuple_ref_for_filescan(resultsym, self.scheme())
             state.saveTupleDef(resultsym, stagedTuple)
 
             tuple_type_def = stagedTuple.generateDefinition()
@@ -595,6 +595,11 @@ class CBaseFileScan(Pipelined, algebra.Scan):
 
         # no return value used because parent is a new pipeline
         self.parent().consume(resultsym, self, state)
+
+    def new_tuple_ref_for_filescan(self, resultsym, scheme):
+        """instance version of new_tuple_ref.
+        Default just calls the cls version"""
+        self.new_tuple_ref(resultsym, scheme)
 
     def consume(self, t, src, state):
         assert False, "as a source, no need for consume"

--- a/raco/language/grappalang.py
+++ b/raco/language/grappalang.py
@@ -1256,6 +1256,12 @@ class GrappaSink(clangcommon.CBaseSink, GrappaOperator):
 
 
 class GrappaFileScan(clangcommon.CBaseFileScan, GrappaOperator):
+    def new_tuple_ref_for_filescan(self, resultsym, scheme):
+        # make new tuple 64-byte aligned if scanning into a global array
+        aligned = self.array_representation == \
+                  _ARRAY_REPRESENTATION.GLOBAL_ARRAY
+        return GrappaStagedTupleRef(resultsym, scheme,
+                                    aligned=aligned)
 
     def __init__(self, representation=_ARRAY_REPRESENTATION.GLOBAL_ARRAY,
                  relation_key=None, _scheme=None, cardinality=None):


### PR DESCRIPTION
Forgot to remove `GRAPPA_BLOCK_ALIGNED` from most MaterializedTupleRef class defs. This attribute is actually only needed when the tuple will be allocated with `global_alloc` or `symmetric_alloc`. Removing this 64-byte alignment should greatly reduce the size of many tuples in queries.