### PR TITLE
Fix failing master branch test?

### DIFF
--- a/c_test_environment/generate_test_relations.py
+++ b/c_test_environment/generate_test_relations.py
@@ -122,15 +122,11 @@ def gen_files():
 
 
 def need_generate(cpdir=''):
-    if not os.path.isfile(os.path.join(cpdir, 'test.db')):
-        return True
+    if os.path.isfile(os.path.join(cpdir, 'test.db')):
+        os.remove(os.path.join(cpdir, 'test.db'))
 
-    for n, _, _, nf in gen_files():
-        fname = get_name(n, nf)
-        if not os.path.isfile(os.path.join(cpdir, fname)):
-            return True
-
-    return False
+    # always re-generate the inputs
+    return True
 
 
 def generate_default(cpdir=None):

--- a/raco/backends/radish/radish.py
+++ b/raco/backends/radish/radish.py
@@ -2514,13 +2514,13 @@ class GrappaAlgebra(Algebra):
                 rules.OneToOne(
                     algebra.GroupBy,
                     groupby_classes['global'])]
-            groupby_class = groupby_classes['global'],
+            groupby_class = groupby_classes['global']
         elif groupby_sematics == 'partition':
             groupby_rules = rules.distributed_group_by(
                 groupby_classes['partition'],
                 countall_rule=False,
                 only_fire_on_multi_key=groupby_classes['global'])
-            groupby_class = groupby_classes['partition'],
+            groupby_class = groupby_classes['partition']
         else:
             raise ValueError(
                 "groupby_semantics must be one of {global, partition}")


### PR DESCRIPTION
Some clang related tests in master failing, despite Travis reporting pass
@jingjingwang 
"test_groupby_string_key" failing? I just ran it using the master branch and got this:

[9:45]  
AssertionError: 
test:  ({(4, 'S2SORBBZ9VO'): 1, (10, 'G59ZSNMHYPGDXK'): 1, (7, 'C83TT4Q'): 1, (2, '3AAFZFZYTH92SIX'): 1, (9, 'JRQX2DB4P1AQZI86BAT'): 1, (10, 'YXJTLICK9QXX7O'): 1, (1, 'N86KJRDXBA9KVQLC688EHW'): 1, (0, '2OGTZY'): 1, (10, 'HPBHPRIIHQ'): 1, (2, '47M5YR9I0DG6H1V4N'): 1, (0, 'SGJZ'): 1, (5, 'RANPGD6S'): 1, (9, 'W2NUICJ6U'): 1, (3, '5V85ETD'): 1, (2, 'I'): 1, (9, 3): 1, (1, '91T4IS8UQJT8A'): 1, (3, 'L46KMTUV'): 1, (4, 'LWCK85L4L70OJA'): 1, (5, '56AHL92M'): 1, (8, '503SUPC5UHSRMMTWWQBI'): 1, (0, 'CCWK2R5FS2C8G1'): 1, (10, 'J23AYDE5BI9'): 1, (1, '4223J4YCAA1IDWM'): 1, (4, 'GI0'): 1, (6, 'G94ELZZ7P3YKV54S'): 1, (0, 52): 1, (6, 'coffee'): 1, (10, 'LDS7K6F6BL62640YGPFZ'): 1, (3, 4): 1}, []) !=
expect:({(4, 'S2SORBBZ9VO'): 1, (10, 'G59ZSNMHYPGDXK'): 1, (3, ComparableFloat(4.0)): 1, (7, 'C83TT4Q'): 1, (2, '3AAFZFZYTH92SIX'): 1, (9, 'JRQX2DB4P1AQZI86BAT'): 1, (10, 'YXJTLICK9QXX7O'): 1, (1, 'N86KJRDXBA9KVQLC688EHW'): 1, (0, '2OGTZY'): 1, (9, ComparableFloat(3.0)): 1, (2, '47M5YR9I0DG6H1V4N'): 1, (0, 'SGJZ'): 1, (5, 'RANPGD6S'): 1, (1, '4223J4YCAA1IDWM'): 1, (0, ComparableFloat(52.0)): 1, (3, '5V85ETD'): 1, (2, 'I'): 1, (1, '91T4IS8UQJT8A'): 1, (10, 'HPBHPRIIHQ'): 1, (3, 'L46KMTUV'): 1, (4, 'LWCK85L4L70OJA'): 1, (5, '56AHL92M'): 1, (8, '503SUPC5UHSRMMTWWQBI'): 1, (0, 'CCWK2R5FS2C8G1'): 1, (10, 'J23AYDE5BI9'): 1, (9, 'W2NUICJ6U'): 1, (4, 'GI0'): 1, (6, 'G94ELZZ7P3YKV54S'): 1, (6, 'coffee'): 1, (10, 'LDS7K6F6BL62640YGPFZ'): 1}, [])

my guess is that it might have passed in Travis because it depends on a PRNG, so the bug can be hidden