### PR TITLE
RACO support for MyriaX Split operator

### DIFF
--- a/raco/algebra.py
+++ b/raco/algebra.py
@@ -618,6 +618,51 @@ def project_partitioning(columnlist, input_partitioning):
         return RepresentationProperties()
 
 
+class StringSplit(UnaryOperator):
+
+    def __init__(self, split_column=None, regex=None, input=None):
+        """Split the specified column of the input using the specified regex.
+
+        :param split_col_index: index of input column to split
+        :type split_col_index: int
+
+        :param regex: valid Java regex
+        :type regex: string
+        """
+
+        UnaryOperator.__init__(self, input)
+        # Raise a TypeError if `splitcol` is not a valid attribute reference in the input schema
+        self.split_column = split_column
+        self.regex = regex
+
+    def __eq__(self, other):
+        return UnaryOperator.__eq__(self, other) and self.split_column == other.split_column and self.regex == other.regex
+
+    def __repr__(self):
+        return "{op}({col!r}, {reg!r}, {inp!r})".format(op=self.opname(),
+                                               col=self.split_column,
+                                               reg=self.regex,
+                                               inp=self.input)
+
+    def partitioning(self):
+        return self.input.partitioning()
+
+    def num_tuples(self):
+        # TODO: this is obviously bogus
+        return self.input.num_tuples()
+
+    def copy(self, other):
+        self.split_column = other.split_column
+        self.regex = other.regex
+        UnaryOperator.copy(self, other)
+
+    def scheme(self):
+        return self.input.scheme()
+
+    def shortStr(self):
+        return "%s(%s, '%s')" % (self.opname(), self.split_column.get_position(self.scheme()), self.regex)
+
+
 class Apply(UnaryOperator):
 
     def __init__(self, emitters=None, input=None):

--- a/raco/algebra.py
+++ b/raco/algebra.py
@@ -1,5 +1,6 @@
 from raco import expression
 from raco import scheme
+from raco import types
 from raco.utility import Printable, real_str
 
 from abc import ABCMeta, abstractmethod
@@ -657,7 +658,9 @@ class StringSplit(UnaryOperator):
         UnaryOperator.copy(self, other)
 
     def scheme(self):
-        return self.input.scheme()
+        split_column_name = self.input.scheme().getName(self.split_column.get_position(self.input.scheme()))
+        split_values_column_name = "%s_splits" % split_column_name
+        return self.input.scheme() + scheme.Scheme(attributes=[(split_values_column_name, types.STRING_TYPE)])
 
     def shortStr(self):
         return "%s(%s, '%s')" % (self.opname(), self.split_column.get_position(self.scheme()), self.regex)

--- a/raco/backends/myria/myria.py
+++ b/raco/backends/myria/myria.py
@@ -221,6 +221,15 @@ class MyriaLimit(algebra.Limit, MyriaOperator):
             "numTuples": self.count,
         }
 
+class MyriaStringSplit(algebra.StringSplit, MyriaOperator):
+
+    def compileme(self, inputid):
+        return {
+            "opType": "Split",
+            "argChild": inputid,
+            "splitColumnIndex": self.split_column.get_position(self.input.scheme()),
+            "regex": self.regex,
+        }
 
 class MyriaUnionAll(algebra.UnionAll, MyriaOperator):
 
@@ -1663,6 +1672,7 @@ myriafy = [
     rules.OneToOne(algebra.Difference, MyriaDifference),
     rules.OneToOne(algebra.OrderBy, MyriaInMemoryOrderBy),
     rules.OneToOne(algebra.Sink, MyriaSink),
+    rules.OneToOne(algebra.StringSplit, MyriaStringSplit),
 ]
 
 # 9. break communication boundary

--- a/raco/myrial/interpreter.py
+++ b/raco/myrial/interpreter.py
@@ -316,6 +316,11 @@ class ExpressionProcessor(object):
         condition = reduce(andify, join_conditions)
         return raco.algebra.Join(condition, left, right)
 
+    def split(self, _id, column_ref, regex):
+        alias_expr = ("ALIAS", _id)
+        child_op = self.evaluate(alias_expr)
+        split_column = get_unnamed_ref(column_ref, child_op.scheme(), 0)
+        return raco.algebra.StringSplit(input=child_op, split_column=split_column, regex=regex)
 
 class StatementProcessor(object):
 

--- a/raco/myrial/parser.py
+++ b/raco/myrial/parser.py
@@ -659,6 +659,11 @@ class Parser(object):
         p[0] = (p[1], p[3])
 
     @staticmethod
+    def p_string_split(p):
+        'expression : SPLIT LPAREN unreserved_id COMMA column_ref COMMA STRING_LITERAL RPAREN'
+        p[0] = ('SPLIT', p[3], p[5], p[7])
+
+    @staticmethod
     def p_literal_arg(p):
         """literal_arg : STRING_LITERAL
                        | INTEGER_LITERAL

--- a/raco/myrial/scanner.py
+++ b/raco/myrial/scanner.py
@@ -7,7 +7,7 @@ import raco.myrial.exceptions
 
 keywords = ['WHILE', 'DO', 'DEF', 'APPLY', 'CASE', 'WHEN', 'THEN',
             'ELSE', 'END', 'CONST', 'LOAD', 'DUMP', 'CSV', 'SCHEMA',
-            'OPP', 'TIPSY', 'UDA', 'TRUE', 'FALSE']
+            'OPP', 'TIPSY', 'SPLIT', 'UDA', 'TRUE', 'FALSE']
 
 types = ['INT', 'STRING', 'FLOAT', 'BOOLEAN']
 


### PR DESCRIPTION
This is embarrassingly ad-hoc but seems to work end-to-end. I'm not sure it should ever be merged into `master`: instead it should be viewed as a trial run for `FlatMap` support, much like the `Split` operator itself. Note that a debatable design decision I made in the Myria `Split` operator was to add an extra column to the operator output called `X_splits`, where `X` is the name of the column being split. I think I didn't account for this correctly in my (non-)override of `UnaryOperator.scheme()`, but I'm not sure it matters much for now--let me know if you think otherwise.