### PR TITLE
Implement streaming operator

### DIFF
--- a/raco/algebra.py
+++ b/raco/algebra.py
@@ -1706,6 +1706,26 @@ class Sink(UnaryOperator):
         return "{op}({pl!r})".format(op=self.opname(), pl=self.input)
 
 
+class Stream(UnaryOperator):
+
+    """Stream query results back to the client."""
+
+    def __init__(self, input=None):
+        UnaryOperator.__init__(self, input)
+
+    def num_tuples(self):
+        return self.input.num_tuples()
+
+    def partitioning(self):
+        return self.input.partitioning()
+
+    def shortStr(self):
+        return "{op}".format(op=self.opname())
+
+    def __repr__(self):
+        return "{op}({pl!r})".format(op=self.opname(), pl=self.input)
+
+
 class Parallel(NaryOperator):
 
     """Execute a set of independent plans in parallel."""

--- a/raco/myrial/interpreter.py
+++ b/raco/myrial/interpreter.py
@@ -402,6 +402,15 @@ class StatementProcessor(object):
         uses_set = self.ep.get_and_clear_uses_set()
         self.cfg.add_op(op, None, uses_set)
 
+    def stream(self, _id):
+        alias_expr = ("ALIAS", _id)
+        child_op = self.ep.evaluate(alias_expr)
+
+        op = raco.algebra.Stream(child_op)
+
+        uses_set = self.ep.get_and_clear_uses_set()
+        self.cfg.add_op(op, None, uses_set)
+
     def dump(self, _id):
         alias_expr = ("ALIAS", _id)
         child_op = self.ep.evaluate(alias_expr)

--- a/raco/myrial/parser.py
+++ b/raco/myrial/parser.py
@@ -507,6 +507,11 @@ class Parser(object):
         p[0] = ('SINK', p[3])
 
     @staticmethod
+    def p_statement_stream(p):
+        'statement : STREAM LPAREN unreserved_id RPAREN SEMI'  # noqa
+        p[0] = ('STREAM', p[3])
+
+    @staticmethod
     def p_statement_dump(p):
         'statement : DUMP LPAREN unreserved_id RPAREN SEMI'
         p[0] = ('DUMP', p[3])

--- a/raco/myrial/scanner.py
+++ b/raco/myrial/scanner.py
@@ -17,7 +17,7 @@ word_operators = ['AND', 'OR', 'NOT']
 
 builtins = ['EMPTY', 'WORKER_ID', 'SCAN', 'COUNTALL', 'COUNT', 'STORE',
             'DIFF', 'CROSS', 'JOIN', 'UNIONALL', 'INTERSECT', 'DISTINCT',
-            'LIMIT', 'SINK', 'SAMPLESCAN', 'LIKE']
+            'LIMIT', 'SINK', 'STREAM', 'SAMPLESCAN', 'LIKE']
 
 
 # identifiers with special meaning; case-insensitive


### PR DESCRIPTION
The design is described in https://github.com/uwescience/myria/pull/858. RACO does the work of translating a `stream(relationVar)` statement into a logical `Stream` operator, and expanding that into a physical operator chain `CollectProducer->CollectConsumer->StreamingSink`, while MyriaX expands `StreamingSink` into a `TupleSink` with `PipeSink` instances that register their `InputStream`s under the running query, so we can construct an HTTP streaming response entity with the sequenced output of all `stream()` statements.