### PR TITLE
Add recursive idb support

### DIFF
--- a/raco/algebra.py
+++ b/raco/algebra.py
@@ -70,6 +70,8 @@ class Operator(Printable):
     def walk(self):
         """Return an iterator over the tree of operators."""
         yield self
+        if self.stop_recursion:
+            return
         for c in self.children():
             for x in c.walk():
                 yield x
@@ -1998,11 +2000,12 @@ class DoWhile(NaryOperator):
 
 class UntilConvergence(NaryOperator):
 
-    def __init__(self, ops=None):
+    def __init__(self, ops=None, pull_order=None):
         """Repeatedly execute a sequence of plans until convergence.
         :params ops: A list of operations to execute in parallel.
         """
         NaryOperator.__init__(self, ops)
+        self.pull_order = pull_order
 
     def partitioning(self):
         return RepresentationProperties()

--- a/raco/algebra.py
+++ b/raco/algebra.py
@@ -122,8 +122,8 @@ class Operator(Printable):
 
     def __str__(self):
         if not self.stop_recursion:
-          if len(self.children()) > 0:
-              return "%s%s" % (self.shortStr(), real_str(self.children()))
+            if len(self.children()) > 0:
+                return "%s%s" % (self.shortStr(), real_str(self.children()))
         return self.shortStr()
 
     def __hash__(self):

--- a/raco/algebra.py
+++ b/raco/algebra.py
@@ -104,7 +104,7 @@ class Operator(Printable):
         if parent_map is None:
             parent_map = {}
         for c in self.children():
-            parent_map.setdefault(c, []).append(self)
+            parent_map.setdefault(id(c), []).append(self)
             c.collectParents(parent_map)
 
     def __copy__(self):

--- a/raco/backends/myria/myria.py
+++ b/raco/backends/myria/myria.py
@@ -813,7 +813,7 @@ class MyriaShuffleProducer(algebra.UnaryOperator, MyriaOperator):
             "argChild": inputid,
             "distributeFunction": df
         }
-        if self.buffer_type is not "None":
+        if self.buffer_type is not None:
             ret.update({"argBufferStateType": self.buffer_type})
 
         return ret
@@ -2106,10 +2106,10 @@ class DoUntilConvergence(rules.Rule):
         return ("DoUntilConvergence")
 
 
-def idb_until_convergence(**kwargs):
+def idb_until_convergence(async_ft):
     ret = [DoUntilConvergence(), RemoveEmptyFilter(), StoreFromIDB(),
            RemoveSingleSplit()]
-    if kwargs.get('async_ft', 'None') is not None:
+    if async_ft is not None:
         ret.append(PropagateAsyncFTBuffer())
     return ret
 
@@ -2151,7 +2151,7 @@ class MyriaLeftDeepTreeAlgebra(MyriaAlgebra):
             myriafy,
             [AddAppendTemp()],
             break_communication,
-            idb_until_convergence(),
+            idb_until_convergence(kwargs.get('async_ft', None)),
         ]
 
         if kwargs.get('add_splits', True):
@@ -2412,4 +2412,4 @@ def compile_to_json(raw_query, logical_plan, physical_plan,
 
     return {"rawQuery": raw_query, "logicalRa": str(logical_plan),
             "language": language, "plan": compile_plan(physical_plan),
-            "ftMode": kwargs.get('async_ft', None)}
+            "ftMode": kwargs.get('async_ft', "NONE")}

--- a/raco/backends/myria/myria.py
+++ b/raco/backends/myria/myria.py
@@ -1869,8 +1869,7 @@ def compile_fragment(frag_root):
     # A dictionary mapping each object to a unique, object-dependent id.
     # Since we want this to be truly unique for each object instance, even if
     # two objects are equal, we use id(obj) as the key.
-    opid_factory = OpIdFactory()
-    op_ids = defaultdict(opid_factory.getter())
+    op_ids = defaultdict(OpIdFactory().getter())
 
     def one_fragment(rootOp):
         """Given an operator that is the root of a query fragment/plan, extract

--- a/raco/backends/myria/myria.py
+++ b/raco/backends/myria/myria.py
@@ -1972,7 +1972,7 @@ class StoreFromIDB(rules.Rule):
         return op
 
     def __str__(self):
-        return ("Store[relation](IDBScan(IDBController)) ->"
+        return ("Store[relation](IDBScan(IDBController)) -> "
                 "IDBController[relation]")
 
 
@@ -1986,6 +1986,8 @@ def replace_child_with(op, child, replacement):
             op.right = replacement
     elif isinstance(op, algebra.NaryOperator):
         op.args[op.args.index(child)] = replacement
+    else:  # should not happen
+        assert False
 
 
 class RemoveEmptyFilter(rules.Rule):
@@ -2071,7 +2073,7 @@ class DoUntilConvergence(rules.Rule):
     def fire(self, op):
         if not isinstance(op, algebra.UntilConvergence):
             return op
-        if any(isinstance(ch, MyriaEOSController) for ch in op.args):
+        if any(isinstance(ch, MyriaEOSController) for ch in op.children()):
             return op
 
         eos_controller = MyriaEOSController()
@@ -2151,7 +2153,7 @@ class MyriaLeftDeepTreeAlgebra(MyriaAlgebra):
             myriafy,
             [AddAppendTemp()],
             break_communication,
-            idb_until_convergence(kwargs.get('async_ft', None)),
+            idb_until_convergence(kwargs.get('async_ft')),
         ]
 
         if kwargs.get('add_splits', True):
@@ -2160,7 +2162,7 @@ class MyriaLeftDeepTreeAlgebra(MyriaAlgebra):
         # so we always need BreakSplit
         compile_grps_sequence.append([BreakSplit()])
 
-        if kwargs.get('join_pull_order', 'None') is not None:
+        if kwargs.get('join_pull_order') is not None:
             compile_grps_sequence.append(
                 [FillInJoinPullOrder(kwargs.get('join_pull_order'))])
 

--- a/raco/backends/myria/myria.py
+++ b/raco/backends/myria/myria.py
@@ -2058,7 +2058,7 @@ class MyriaLeftDeepTreeAlgebra(MyriaAlgebra):
         if kwargs.get('join_pull_order'):
             compile_grps_sequence.append(
                 [FillInJoinPullOrder(kwargs.get('join_pull_order'))])
-        if kwargs.get('async_ft'):
+        if kwargs.get('async_ft') is not None:
             compile_grps_sequence.append([PropagateAsyncFTBuffer()])
 
         rule_grps_sequence = opt_grps_sequence + compile_grps_sequence
@@ -2281,7 +2281,7 @@ def compile_plan(plan_op):
 
 
 def compile_to_json(raw_query, logical_plan, physical_plan,
-                    language="not specified"):
+                    language="not specified", **kwargs):
     """This function compiles a physical query plan to the JSON suitable for
     submission to the Myria REST API server. The logical plan is converted to a
     string and passed along unchanged."""
@@ -2299,7 +2299,7 @@ def compile_to_json(raw_query, logical_plan, physical_plan,
     # raw_query must be a string
     if not isinstance(raw_query, basestring):
         raise ValueError("raw query must be a string")
-    return {"rawQuery": raw_query,
-            "logicalRa": str(logical_plan),
-            "language": language,
-            "plan": compile_plan(physical_plan)}
+
+    return {"rawQuery": raw_query, "logicalRa": str(logical_plan),
+            "language": language, "plan": compile_plan(physical_plan),
+            "ftMode": kwargs.get('async_ft')}

--- a/raco/compile.py
+++ b/raco/compile.py
@@ -43,6 +43,8 @@ def optimize_by_rules(expr, rules):
         def recursiverule(e):
             newe = rule(e)
             writer.write_if_enabled(newe, str(rule))
+            if newe.stop_recursion:
+                return newe
 
             # log the optimizer step
             if str(e) == str(newe):

--- a/raco/expression/aggregate.py
+++ b/raco/expression/aggregate.py
@@ -203,7 +203,7 @@ class MIN(UnaryFunction, TrivialAggregateExpression):
         return self.input.typeof(scheme, state_scheme)
 
 
-class MULTIMIN(NaryFunction, TrivialAggregateExpression):
+class LEXMIN(NaryFunction, TrivialAggregateExpression):
     # TODO: support for fakedb
     def evaluate_aggregate(self, tuple_iterator, scheme):
         raise NotImplementedError()

--- a/raco/expression/aggregate.py
+++ b/raco/expression/aggregate.py
@@ -3,7 +3,7 @@ Aggregate expressions for use in Raco
 """
 
 from .expression import *
-from .function import UnaryFunction, SQRT, POW
+from .function import UnaryFunction, SQRT, POW, NaryFunction
 from .statevar import *
 from raco import types
 from abc import abstractmethod
@@ -201,6 +201,15 @@ class MIN(UnaryFunction, TrivialAggregateExpression):
 
     def typeof(self, scheme, state_scheme):
         return self.input.typeof(scheme, state_scheme)
+
+
+class MULTIMIN(NaryFunction, TrivialAggregateExpression):
+    # TODO: support for fakedb
+    def evaluate_aggregate(self, tuple_iterator, scheme):
+        raise NotImplementedError()
+
+    def typeof(self, scheme, state_scheme):
+        raise NotImplementedError()
 
 
 class COUNTALL(ZeroaryOperator, BuiltinAggregateExpression):

--- a/raco/expression/expressions_library.py
+++ b/raco/expression/expressions_library.py
@@ -29,6 +29,12 @@ def create_nested_binary(num_args, func):
     return Function(var, reduce(func, var_refs))
 
 
+def create_variable_length_function(num_args, func):
+    var = ["x{i}".format(i=i + 1) for i in xrange(num_args)]
+    var_refs = [NamedAttributeRef(vstr) for vstr in var]
+    return Function(var, func(var_refs))
+
+
 # mapping from name -> dict or Function
 # the dict is a mapping from arity -> Function
 EXPRESSIONS_CASE = {
@@ -47,6 +53,8 @@ EXPRESSIONS_CASE = {
     'greatest': lambda num_args: create_nested_binary(num_args, GREATER),
     'least': lambda num_args: create_nested_binary(num_args, LESSER),
     'greater': create_nested_binary(2, GREATER),
+    'MultiMin': lambda num_args:
+        create_variable_length_function(num_args, MULTIMIN),
     'lesser': create_nested_binary(2, LESSER),
     'substr': Function(['str', 'begin', 'end'],
                        SUBSTR([NamedAttributeRef('str'),

--- a/raco/expression/expressions_library.py
+++ b/raco/expression/expressions_library.py
@@ -53,8 +53,8 @@ EXPRESSIONS_CASE = {
     'greatest': lambda num_args: create_nested_binary(num_args, GREATER),
     'least': lambda num_args: create_nested_binary(num_args, LESSER),
     'greater': create_nested_binary(2, GREATER),
-    'MultiMin': lambda num_args:
-        create_variable_length_function(num_args, MULTIMIN),
+    'lexmin': lambda num_args:
+        create_variable_length_function(num_args, LEXMIN),
     'lesser': create_nested_binary(2, LESSER),
     'substr': Function(['str', 'begin', 'end'],
                        SUBSTR([NamedAttributeRef('str'),

--- a/raco/myrial/cfg.py
+++ b/raco/myrial/cfg.py
@@ -221,6 +221,9 @@ class ControlFlowGraph(object):
                 if self.graph.in_degree(nodeB) == 2:
                     continue  # start of do/while loop
 
+                if isinstance(self.graph.node[nodeB]['op'], UntilConvergence):
+                    continue  # start of do/until convergence
+
                 def_var = self.graph.node[nodeA]['def_var']
                 if not def_var:
                     continue

--- a/raco/myrial/emitarg.py
+++ b/raco/myrial/emitarg.py
@@ -96,7 +96,7 @@ class NaryEmitArg(EmitArg):
         return self.statemods
 
     def __repr__(self):
-        return 'NaryEmitArg(%r)' % self.sexprs
+        return 'NaryEmitArg(%r,%r)' % (self.column_names, self.sexprs)
 
 
 def expand_relation(relation_name, symbols):

--- a/raco/myrial/emitarg.py
+++ b/raco/myrial/emitarg.py
@@ -96,7 +96,8 @@ class NaryEmitArg(EmitArg):
         return self.statemods
 
     def __repr__(self):
-        return 'NaryEmitArg(%r,%r)' % (self.column_names, self.sexprs)
+        return 'NaryEmitArg(%r,%r,%r)' % (
+            self.column_names, self.sexprs, self.statemods)
 
 
 def expand_relation(relation_name, symbols):

--- a/raco/myrial/interpreter.py
+++ b/raco/myrial/interpreter.py
@@ -494,12 +494,10 @@ class StatementProcessor(object):
         for _type, _id, emits, expr in statement_list:
             if _id in self.symbols:
                 raise InvalidStatementException('IDB %s is already used' % _id)
-
-            emit_args = [emit.sexprs[0] for emit in emits]
             idbcontroller = raco.algebra.IDBController(
                 _id, idx,
                 [None, None, raco.algebra.EmptyRelation(raco.scheme.Scheme())],
-                emit_args, None, recursion_mode)
+                emits, None, recursion_mode)
             idbs[_id] = idbcontroller
             self.symbols[_id] = raco.algebra.ScanIDB(_id, None, idbcontroller)
             idx = idx + 1

--- a/raco/myrial/interpreter.py
+++ b/raco/myrial/interpreter.py
@@ -488,7 +488,7 @@ class StatementProcessor(object):
                 return [expr]
         return []
 
-    def untilconvergence(self, statement_list, recursion_mode):
+    def untilconvergence(self, statement_list, recursion_mode, pull_order):
         idbs = {}
         idx = 0
         for _type, _id, emits, expr in statement_list:
@@ -536,7 +536,7 @@ class StatementProcessor(object):
                             [self.ep.evaluate(expr)
                              for expr in iterative_inputs])
 
-        op = raco.algebra.UntilConvergence(idbs.values())
+        op = raco.algebra.UntilConvergence(idbs.values(), pull_order)
         uses_set = self.ep.get_and_clear_uses_set()
         self.cfg.add_op(op, None, uses_set)
 

--- a/raco/myrial/interpreter.py
+++ b/raco/myrial/interpreter.py
@@ -488,7 +488,8 @@ class StatementProcessor(object):
                 return [expr]
         return []
 
-    def untilconvergence(self, statement_list, recursion_mode, pull_order):
+    def untilconvergence(self, statement_list, recursion_mode,
+                         pull_order_policy):
         idbs = {}
         idx = 0
         for _type, _id, emits, expr in statement_list:
@@ -536,7 +537,7 @@ class StatementProcessor(object):
                             [self.ep.evaluate(expr)
                              for expr in iterative_inputs])
 
-        op = raco.algebra.UntilConvergence(idbs.values(), pull_order)
+        op = raco.algebra.UntilConvergence(idbs.values(), pull_order_policy)
         uses_set = self.ep.get_and_clear_uses_set()
         self.cfg.add_op(op, None, uses_set)
 

--- a/raco/myrial/interpreter.py
+++ b/raco/myrial/interpreter.py
@@ -386,7 +386,7 @@ class StatementProcessor(object):
         """Map an IDB to the value of an expression."""
         self.__do_assignment(_id, expr)
 
-    def store(self, _id, rel_key, how_partitioned):
+    def store(self, _id, rel_key, how_distributed):
         assert isinstance(rel_key, relation_key.RelationKey)
 
         alias_expr = ("ALIAS", _id)

--- a/raco/myrial/myrial_test.py
+++ b/raco/myrial/myrial_test.py
@@ -16,8 +16,10 @@ class MyrialTestCase(unittest.TestCase):
 
     def setUp(self):
         self.db = self.create_db()
-
         self.parser = parser.Parser()
+        self.new_processor()
+
+    def new_processor(self):
         self.processor = interpreter.StatementProcessor(self.db)
 
     def parse(self, query):

--- a/raco/myrial/optimizer_tests.py
+++ b/raco/myrial/optimizer_tests.py
@@ -12,7 +12,7 @@ from raco.expression import aggregate
 from raco.backends.myria import (
     MyriaShuffleConsumer, MyriaShuffleProducer, MyriaHyperCubeShuffleProducer,
     MyriaBroadcastConsumer, MyriaQueryScan, MyriaSplitConsumer, MyriaUnionAll,
-    MyriaBroadcastProducer, MyriaScan, MyriaSelect,
+    MyriaBroadcastProducer, MyriaScan, MyriaSelect, MyriaSplitProducer,
     MyriaDupElim, MyriaGroupBy, MyriaIDBController, compile_to_json)
 from raco.backends.myria import (MyriaLeftDeepTreeAlgebra,
                                  MyriaHyperCubeAlgebra)
@@ -1273,11 +1273,11 @@ class OptimizerTest(myrial_test.MyrialTestCase):
         """
         lp = self.get_logical_plan(query, async_ft='REJOIN')
         pp = self.logical_to_physical(lp, async_ft='REJOIN')
-        for op in pp.walk():
+        for op in pp.children():
             for child in op.children():
                 if isinstance(child, MyriaIDBController):
                     # for checking rule RemoveSingleSplit
-                    assert isinstance(op, MyriaShuffleProducer)
+                    assert not isinstance(op, MyriaSplitProducer)
         plan = compile_to_json(query, lp, pp, 'myrial', async_ft='REJOIN')
 
         self.assertEquals(plan['ftMode'], 'REJOIN')

--- a/raco/myrial/parser.py
+++ b/raco/myrial/parser.py
@@ -416,6 +416,15 @@ class Parser(object):
         p[0] = p[1] or []
 
     @staticmethod
+    def p_pull_order(p):
+        """pull_order : ALTER
+                      | PULL_IDB
+                      | PULL_EDB
+                      | BUILD_EDB
+                      | empty"""
+        p[0] = p[1] or []
+
+    @staticmethod
     def p_function_arg_list(p):
         """function_arg_list : function_arg_list COMMA unreserved_id
                              | unreserved_id"""
@@ -520,8 +529,9 @@ class Parser(object):
 
     @staticmethod
     def p_statement_dountilconvergence(p):
-        'statement : DO idbassign_list UNTIL CONVERGENCE recursion_mode SEMI'
-        p[0] = ('UNTILCONVERGENCE', p[2], p[5])
+        ('statement : DO idbassign_list UNTIL CONVERGENCE '
+         'recursion_mode pull_order SEMI')
+        p[0] = ('UNTILCONVERGENCE', p[2], p[5], p[6])
 
     @staticmethod
     def p_statement_store(p):

--- a/raco/myrial/parser.py
+++ b/raco/myrial/parser.py
@@ -409,6 +409,13 @@ class Parser(object):
         p[0] = p[1] or []
 
     @staticmethod
+    def p_recursion_mode(p):
+        """recursion_mode : SYNC
+                          | ASYNC
+                          | empty"""
+        p[0] = p[1] or []
+
+    @staticmethod
     def p_function_arg_list(p):
         """function_arg_list : function_arg_list COMMA unreserved_id
                              | unreserved_id"""
@@ -470,6 +477,12 @@ class Parser(object):
         p[0] = ('ASSIGN', p[1], p[3])
 
     @staticmethod
+    def p_statement_idbassign(p):
+        'statement : unreserved_id COLON EQUALS LBRACKET emit_arg_list \
+            RBRACKET LARROW rvalue SEMI'
+        p[0] = ('IDBASSIGN', p[1], p[5], p[8])
+
+    @staticmethod
     def p_statement_empty(p):
         'statement : SEMI'
         p[0] = None  # stripped out by parse
@@ -495,6 +508,11 @@ class Parser(object):
     def p_statement_dowhile(p):
         'statement : DO statement_list WHILE expression SEMI'
         p[0] = ('DOWHILE', p[2], p[4])
+
+    @staticmethod
+    def p_statement_dountilconvergence(p):
+        'statement : DO statement_list UNTIL CONVERGENCE recursion_mode SEMI'
+        p[0] = ('UNTILCONVERGENCE', p[2], p[5])
 
     @staticmethod
     def p_statement_store(p):

--- a/raco/myrial/parser.py
+++ b/raco/myrial/parser.py
@@ -416,12 +416,12 @@ class Parser(object):
         p[0] = p[1] or []
 
     @staticmethod
-    def p_pull_order(p):
-        """pull_order : ALTER
-                      | PULL_IDB
-                      | PULL_EDB
-                      | BUILD_EDB
-                      | empty"""
+    def p_pull_order_policy(p):
+        """pull_order_policy : ALTERNATE
+                             | PULL_IDB
+                             | PULL_EDB
+                             | BUILD_EDB
+                             | empty"""
         p[0] = p[1] or []
 
     @staticmethod
@@ -530,7 +530,7 @@ class Parser(object):
     @staticmethod
     def p_statement_dountilconvergence(p):
         ('statement : DO idbassign_list UNTIL CONVERGENCE '
-         'recursion_mode pull_order SEMI')
+         'recursion_mode pull_order_policy SEMI')
         p[0] = ('UNTILCONVERGENCE', p[2], p[5], p[6])
 
     @staticmethod

--- a/raco/myrial/parser.py
+++ b/raco/myrial/parser.py
@@ -477,10 +477,10 @@ class Parser(object):
         p[0] = ('ASSIGN', p[1], p[3])
 
     @staticmethod
-    def p_statement_idbassign(p):
-        'statement : unreserved_id COLON EQUALS LBRACKET emit_arg_list \
+    def p_idbassign(p):
+        'idbassign : unreserved_id EQUALS LBRACKET emit_arg_list \
             RBRACKET LARROW rvalue SEMI'
-        p[0] = ('IDBASSIGN', p[1], p[5], p[8])
+        p[0] = ('IDBASSIGN', p[1], p[4], p[7])
 
     @staticmethod
     def p_statement_empty(p):
@@ -494,6 +494,15 @@ class Parser(object):
         """rvalue : expression
                   | select_from_where"""
         p[0] = p[1]
+
+    @staticmethod
+    def p_idbassign_list(p):
+        """idbassign_list : idbassign_list idbassign
+                          | idbassign"""
+        if len(p) == 3:
+            p[0] = p[1] + [p[2]]
+        else:
+            p[0] = [p[1]]
 
     @staticmethod
     def p_statement_list(p):
@@ -511,7 +520,7 @@ class Parser(object):
 
     @staticmethod
     def p_statement_dountilconvergence(p):
-        'statement : DO statement_list UNTIL CONVERGENCE recursion_mode SEMI'
+        'statement : DO idbassign_list UNTIL CONVERGENCE recursion_mode SEMI'
         p[0] = ('UNTILCONVERGENCE', p[2], p[5])
 
     @staticmethod

--- a/raco/myrial/scanner.py
+++ b/raco/myrial/scanner.py
@@ -7,7 +7,8 @@ import raco.myrial.exceptions
 
 keywords = ['WHILE', 'DO', 'DEF', 'APPLY', 'CASE', 'WHEN', 'THEN',
             'ELSE', 'END', 'CONST', 'LOAD', 'DUMP', 'CSV', 'SCHEMA',
-            'OPP', 'TIPSY', 'UDA', 'TRUE', 'FALSE']
+            'OPP', 'TIPSY', 'UDA', 'TRUE', 'FALSE',
+            'UNTIL', 'CONVERGENCE', "SYNC", "ASYNC"]
 
 types = ['INT', 'STRING', 'FLOAT', 'BOOLEAN']
 
@@ -29,7 +30,7 @@ reserved = (keywords + types + comprehension_keywords
 tokens = ['LPAREN', 'RPAREN', 'LBRACKET', 'RBRACKET', 'DOT', 'PLUS', 'MINUS',
           'TIMES', 'DIVIDE', 'IDIVIDE', 'MOD', 'LT', 'GT', 'GE', 'GE2',
           'LE', 'LE2', 'EQ', 'NE', 'NE2', 'NE3', 'COMMA', 'SEMI', 'EQUALS',
-          'COLON', 'DOLLAR', 'ID',
+          'COLON', 'DOLLAR', 'ID', 'LARROW',
           'STRING_LITERAL', 'INTEGER_LITERAL', 'FLOAT_LITERAL',
           'LBRACE', 'RBRACE'] + reserved
 
@@ -65,6 +66,7 @@ t_SEMI = r';'
 t_EQUALS = r'='
 t_COLON = r':'
 t_DOLLAR = r'\$'
+t_LARROW = r'<-'
 
 # Regular expressions for non-trivial tokens
 

--- a/raco/myrial/scanner.py
+++ b/raco/myrial/scanner.py
@@ -8,7 +8,8 @@ import raco.myrial.exceptions
 keywords = ['WHILE', 'DO', 'DEF', 'APPLY', 'CASE', 'WHEN', 'THEN',
             'ELSE', 'END', 'CONST', 'LOAD', 'DUMP', 'CSV', 'SCHEMA',
             'OPP', 'TIPSY', 'UDA', 'TRUE', 'FALSE', 'HASH', 'BROADCAST',
-            'ROUND_ROBIN', 'UNTIL', 'CONVERGENCE', "SYNC", "ASYNC"]
+            'ROUND_ROBIN', 'UNTIL', 'CONVERGENCE', "SYNC", "ASYNC",
+            'ALTER', 'PULL_IDB', 'PULL_EDB', 'BUILD_EDB']
 
 types = ['INT', 'STRING', 'FLOAT', 'BOOLEAN']
 

--- a/raco/myrial/scanner.py
+++ b/raco/myrial/scanner.py
@@ -9,7 +9,7 @@ keywords = ['WHILE', 'DO', 'DEF', 'APPLY', 'CASE', 'WHEN', 'THEN',
             'ELSE', 'END', 'CONST', 'LOAD', 'DUMP', 'CSV', 'SCHEMA',
             'OPP', 'TIPSY', 'UDA', 'TRUE', 'FALSE', 'HASH', 'BROADCAST',
             'ROUND_ROBIN', 'UNTIL', 'CONVERGENCE', "SYNC", "ASYNC",
-            'ALTER', 'PULL_IDB', 'PULL_EDB', 'BUILD_EDB']
+            'ALTERNATE', 'PULL_IDB', 'PULL_EDB', 'BUILD_EDB']
 
 types = ['INT', 'STRING', 'FLOAT', 'BOOLEAN']
 


### PR DESCRIPTION
This PR adds support for a new syntax: a do-until-convergence loop containing a list of special MyriaL statements. The loop terminates when there will be no update to any relation. Examples are those newly added optimizer tests.