### PR TITLE
Fix arguments to variadic (Python) functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "2.7"
 install:
+  - pip install setuptools --upgrade
   - pip install -r requirements-dev.txt
   - python setup.py install
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "2.7"
 install:
+  - pip install pip --upgrade
   - pip install setuptools --upgrade
   - pip install -r requirements-dev.txt
   - python setup.py install

--- a/raco/backends/sql/catalog.py
+++ b/raco/backends/sql/catalog.py
@@ -3,7 +3,7 @@ A RACO language to compile expressions to SQL.
 """
 
 from sqlalchemy import (Column, Table, MetaData, Integer, String,
-                        Float, Boolean, DateTime, select, func,
+                        Float, Boolean, LargeBinary, DateTime, select, func,
                         literal, case)
 
 import raco.algebra as algebra
@@ -19,6 +19,7 @@ type_to_raco = {Integer: types.LONG_TYPE,
                 String: types.STRING_TYPE,
                 Float: types.FLOAT_TYPE,
                 Boolean: types.BOOLEAN_TYPE,
+                LargeBinary: types.BLOB_TYPE,
                 DateTime: types.DATETIME_TYPE}
 
 
@@ -28,6 +29,7 @@ raco_to_type = {types.LONG_TYPE: Integer,
                 types.FLOAT_TYPE: Float,
                 types.DOUBLE_TYPE: Float,
                 types.BOOLEAN_TYPE: Boolean,
+                types.BLOB_TYPE: LargeBinary,
                 types.DATETIME_TYPE: DateTime}
 
 


### PR DESCRIPTION
Prior to this fix, only positional arguments were allowed.  This PR correctly maps arbitrary argument expressions to UDF parameters.