### PR TITLE
Encoding for CSVFragmentTupleSource

### DIFF
--- a/raco/backends/myria/myria.py
+++ b/raco/backends/myria/myria.py
@@ -19,6 +19,7 @@ from raco.expression import WORKERID, COUNTALL
 from raco.representation import RepresentationProperties
 from raco.rules import distributed_group_by, check_partition_equality
 from raco.expression import util
+from urlparse import urlparse
 
 LOGGER = logging.getLogger(__name__)
 
@@ -210,7 +211,21 @@ class MyriaFileScan(algebra.FileScan, MyriaOperator):
             }
 
         else:
-            encoding = {
+            url_parser = urlparse(self.path)
+            if(url_parser.scheme == 's3'):
+                encoding = {
+                    "opType": "CSVFileScanFragment",
+                    "reader": dict({
+                        "readerType": "CSV",
+                        "schema": scheme_to_schema(self.scheme())
+                    }, **self.options),
+                    "source": {
+                        "dataType": "S3",
+                        "s3Uri": self.path
+                    }
+                }
+            else:
+                encoding = {
                 "opType": "TupleSource",
                 "reader": dict({
                     "readerType": "CSV",

--- a/raco/backends/myria/myria.py
+++ b/raco/backends/myria/myria.py
@@ -211,8 +211,8 @@ class MyriaFileScan(algebra.FileScan, MyriaOperator):
             }
 
         else:
-            url_parser = urlparse(self.path)
-            if(url_parser.scheme == 's3'):
+            parsed_url = urlparse(self.path)
+            if parsed_url.scheme == 's3':
                 encoding = {
                     "opType": "CSVFragmentTupleSource",
                     "reader": dict({

--- a/raco/backends/myria/myria.py
+++ b/raco/backends/myria/myria.py
@@ -214,7 +214,7 @@ class MyriaFileScan(algebra.FileScan, MyriaOperator):
             url_parser = urlparse(self.path)
             if(url_parser.scheme == 's3'):
                 encoding = {
-                    "opType": "CSVFileScanFragment",
+                    "opType": "CSVFragmentTupleSource",
                     "reader": dict({
                         "readerType": "CSV",
                         "schema": scheme_to_schema(self.scheme())

--- a/raco/backends/myria/myria.py
+++ b/raco/backends/myria/myria.py
@@ -226,16 +226,16 @@ class MyriaFileScan(algebra.FileScan, MyriaOperator):
                 }
             else:
                 encoding = {
-                "opType": "TupleSource",
-                "reader": dict({
-                    "readerType": "CSV",
-                    "schema": scheme_to_schema(self.scheme())
-                }, **self.options),
-                "source": {
-                    "dataType": "URI",
-                    "uri": self.path
+                    "opType": "TupleSource",
+                    "reader": dict({
+                        "readerType": "CSV",
+                        "schema": scheme_to_schema(self.scheme())
+                    }, **self.options),
+                    "source": {
+                        "dataType": "URI",
+                        "uri": self.path
+                    }
                 }
-            }
 
         return encoding
 


### PR DESCRIPTION
Depends on https://github.com/uwescience/myria/pull/897

Added CSVFragmentTupleSource encoding as the default when loading CSV data from S3.