### PR TITLE
force ordering of partitioning attributes

### DIFF
--- a/raco/backends/myria/catalog.py
+++ b/raco/backends/myria/catalog.py
@@ -86,9 +86,9 @@ class MyriaCatalog(Catalog):
             if distribute_function['type'] == "Identity":
                 index = distribute_function['index']
                 return RepresentationProperties(
-                    hash_partitioned=frozenset(AttIndex(index)))
+                    hash_partitioned=tuple(AttIndex(index)))
             elif distribute_function['type'] == "Hash":
                 indexes = distribute_function['indexes']
                 return RepresentationProperties(
-                    hash_partitioned=frozenset(AttIndex(i) for i in indexes))
+                    hash_partitioned=tuple(AttIndex(i) for i in indexes))
         return RepresentationProperties()

--- a/raco/catalog.py
+++ b/raco/catalog.py
@@ -77,7 +77,7 @@ class FakeCatalog(Catalog):
                 self.sizes[RelationKey(child)] = size
         if child_partitionings:
             for child, part in child_partitionings.items():
-                self.partitionings[RelationKey(child)] = frozenset(part)
+                self.partitionings[RelationKey(child)] = tuple(part)
         if child_functions:
             for child, typ in child_functions.items():
                 self.functions[child] = funcObj

--- a/raco/myrial/optimizer_tests.py
+++ b/raco/myrial/optimizer_tests.py
@@ -39,7 +39,7 @@ class OptimizerTest(myrial_test.MyrialTestCase):
     part_key = relation_key.RelationKey.from_string("public:adhoc:part")
     broad_key = relation_key.RelationKey.from_string("public:adhoc:broad")
     part_partition = RepresentationProperties(
-        hash_partitioned=frozenset([AttIndex(1)]))
+        hash_partitioned=tuple([AttIndex(1)]))
     broad_partition = RepresentationProperties(broadcasted=True)
     random.seed(387)  # make results deterministic
     rng = 20
@@ -871,7 +871,7 @@ class OptimizerTest(myrial_test.MyrialTestCase):
         self.assertEquals(self.get_count(pp, MyriaShuffleProducer), 1)
         self.assertEquals(self.get_count(pp, MyriaShuffleConsumer), 1)
         self.assertEquals(pp.partitioning().hash_partitioned,
-                          frozenset([AttIndex(0)]))
+                          tuple([AttIndex(0)]))
 
     def test_partitioning_from_scan(self):
         """Store will know the partitioning of a partitioned store relation"""
@@ -904,7 +904,7 @@ class OptimizerTest(myrial_test.MyrialTestCase):
         self.assertEquals(self.get_count(pp, MyriaShuffleProducer), 1)
         self.assertEquals(self.get_count(pp, MyriaShuffleConsumer), 1)
         self.assertEquals(pp.partitioning().hash_partitioned,
-                          frozenset([AttIndex(2)]))
+                          tuple([AttIndex(2)]))
 
     def test_remove_shuffle(self):
         """No shuffle for hash join needed when the input is partitioned"""
@@ -959,7 +959,7 @@ class OptimizerTest(myrial_test.MyrialTestCase):
         pp = self.logical_to_physical(lp)
 
         self.assertEquals(pp.partitioning().hash_partitioned,
-                          frozenset())
+                          tuple())
 
     def test_apply_maintains_partitioning(self):
         """Projecting out non-partitioned attributes
@@ -975,7 +975,7 @@ class OptimizerTest(myrial_test.MyrialTestCase):
         pp = self.logical_to_physical(lp)
 
         self.assertEquals(pp.partitioning().hash_partitioned,
-                          frozenset([AttIndex(0)]))
+                          tuple([AttIndex(0)]))
 
     def test_swapping_apply_maintains_partitioning(self):
         """Projecting out non-partitioned attributes
@@ -991,7 +991,7 @@ class OptimizerTest(myrial_test.MyrialTestCase):
         pp = self.logical_to_physical(lp)
 
         self.assertEquals(pp.partitioning().hash_partitioned,
-                          frozenset([AttIndex(1)]))
+                          tuple([AttIndex(1)]))
 
     def test_projecting_join_maintains_partitioning(self):
         """Projecting join: projecting out non-partitioned attributes
@@ -1014,7 +1014,7 @@ class OptimizerTest(myrial_test.MyrialTestCase):
         # TODO: this test case forces conservative behavior
         # (in general, info could be h($0) && h($2)
         self.assertEquals(pp.partitioning().hash_partitioned,
-                          frozenset([AttIndex(0)]))
+                          tuple([AttIndex(0)]))
 
     def test_no_shuffle_for_partitioned_distinct(self):
         """Do not shuffle for Distinct if already partitioned"""

--- a/raco/representation.py
+++ b/raco/representation.py
@@ -4,7 +4,7 @@ class RepresentationProperties(object):
 
     def __init__(
             self,
-            hash_partitioned=frozenset(),
+            hash_partitioned=tuple(),
             sorted=None,
             grouped=None,
             broadcasted=False):
@@ -59,5 +59,5 @@ class RepresentationProperties(object):
 
     def __hash__(self):
         """Override the default hash behavior
-        (that returns the id or the object)"""
+        (that returns the id of the object)"""
         return hash(tuple(sorted(self.__dict__.items())))

--- a/raco/rules.py
+++ b/raco/rules.py
@@ -1041,7 +1041,7 @@ def check_partition_equality(op, representation):
     @return true if the op has an equal hash partitioning to representation
     """
 
-    return op.partitioning().hash_partitioned == frozenset(representation)
+    return op.partitioning().hash_partitioned == tuple(representation)
 
 
 class DeDupBroadcastInputs(Rule):


### PR DESCRIPTION
Fixes #515. Unfortunately I can't add a new RACO test to verify this fixes the bug, since FakeDB doesn't support physical representation properties (this is mentioned in https://github.com/uwescience/raco/issues/511), so I added a new integration test to MyriaX (which I'll merge as soon as this PR is merged): https://github.com/uwescience/myria/commit/b4f63165299a062081f5f730ba1becb6fde79e17