### PR TITLE
adding support for OrderBy and Limit in MyriaL

### DIFF
--- a/raco/algebra.py
+++ b/raco/algebra.py
@@ -1237,8 +1237,8 @@ class OrderBy(UnaryOperator):
         return "{op}({inp!r}, {scol!r}, {asc!r})".format(
             op=self.opname(),
             inp=self.input,
-            scol=list(self.sort_columns),
-            asc=list(self.ascending))
+            scol=self.sort_columns,
+            asc=self.ascending)
 
     def num_tuples(self):
         return self.input.num_tuples()

--- a/raco/algebra.py
+++ b/raco/algebra.py
@@ -1221,13 +1221,24 @@ class GroupBy(UnaryOperator):
 
 class OrderBy(UnaryOperator):
 
-    """ Logical Sort operator
-    """
+    """ Logical OrderBy operator"""
 
     def __init__(self, input=None, sort_columns=None, ascending=None):
         UnaryOperator.__init__(self, input)
         self.sort_columns = sort_columns
         self.ascending = ascending
+
+    def __eq__(self, other):
+        return UnaryOperator.__eq__(self, other) and \
+            self.sort_columns == other.sort_columns and \
+            self.ascending == other.ascending
+
+    def __repr__(self):
+        return "{op}({inp!r}, {scol!r}, {asc!r})".format(
+            op=self.opname(),
+            inp=self.input,
+            scol=list(self.sort_columns),
+            asc=list(self.ascending))
 
     def num_tuples(self):
         return self.input.num_tuples()

--- a/raco/backends/myria/myria.py
+++ b/raco/backends/myria/myria.py
@@ -1270,13 +1270,16 @@ class CollectBeforeLimit(rules.Rule):
                                   MyriaLimit(exp.count, exp.input)))
         return exp
 
+
 class GlobalOrderBy(rules.Rule):
 
     def fire(self, exp):
         if exp.__class__ == algebra.OrderBy:
-            return MyriaInMemoryOrderBy(algebra.Collect(
-                                            exp.input),exp.sort_columns, exp.ascending)
+            return MyriaInMemoryOrderBy(
+                algebra.Collect(exp.input),
+                exp.sort_columns, exp.ascending)
         return exp
+
 
 class ShuffleBeforeSetop(rules.Rule):
 
@@ -2445,7 +2448,9 @@ def compile_to_json(raw_query, logical_plan, physical_plan,
     assert isinstance(physical_plan, subplan_ops), \
         'Physical plan must be a subplan operator, not {}'.format(type(physical_plan))  # noqa
 
-    if('OrderBy' in str(logical_plan) and 'Limit' not in str(logical_plan)):
+    if('OrderBy' in str(logical_plan)
+            and 'Limit' not in str(logical_plan)
+            and 'MyriaHyperCube' not in str(logical_plan)):
         raise Exception("OrderBy queries must use the Limit operator")
 
     # raw_query must be a string

--- a/raco/backends/myria/myria.py
+++ b/raco/backends/myria/myria.py
@@ -2433,8 +2433,10 @@ def compile_to_json(raw_query, logical_plan, physical_plan,
     # Store/StoreTemp is a reasonable physical plan... for now.
     root_ops = (algebra.Store, algebra.StoreTemp, algebra.Sink)
     if isinstance(physical_plan, root_ops):
-        if isinstance(logical_plan.input, algebra.OrderBy):
-            raise Exception("Order By queries must use the Limit operator")
+        if isinstance(physical_plan.input, MyriaSplitConsumer):
+            splitOperator = physical_plan.input.input.input
+            if isinstance(splitOperator, MyriaInMemoryOrderBy):
+                raise Exception("Order By queries must use the Limit operator")
         physical_plan = algebra.Parallel([physical_plan])
 
     subplan_ops = (algebra.Parallel, algebra.Sequence, algebra.DoWhile,

--- a/raco/backends/myria/myria.py
+++ b/raco/backends/myria/myria.py
@@ -2433,10 +2433,6 @@ def compile_to_json(raw_query, logical_plan, physical_plan,
     # Store/StoreTemp is a reasonable physical plan... for now.
     root_ops = (algebra.Store, algebra.StoreTemp, algebra.Sink)
     if isinstance(physical_plan, root_ops):
-        if isinstance(physical_plan.input, MyriaSplitConsumer):
-            splitOperator = physical_plan.input.input.input
-            if isinstance(splitOperator, MyriaInMemoryOrderBy):
-                raise Exception("Order By queries must use the Limit operator")
         physical_plan = algebra.Parallel([physical_plan])
 
     subplan_ops = (algebra.Parallel, algebra.Sequence, algebra.DoWhile,

--- a/raco/fakedb.py
+++ b/raco/fakedb.py
@@ -271,7 +271,7 @@ class FakeDatabase(Catalog):
 
     def orderby(self, op):
         it = self.evaluate(op.input)
-        oList = zip(op.sort_columns, op.ascending)
+        oList = reversed(zip(op.sort_columns, op.ascending))
         sortedList = list(it)
         for o in oList:
             sortedList = sorted(

--- a/raco/fakedb.py
+++ b/raco/fakedb.py
@@ -269,6 +269,15 @@ class FakeDatabase(Catalog):
         it = self.evaluate(op.input)
         return itertools.islice(it, op.count)
 
+    def orderby(self, op):
+        it = self.evaluate(op.input)
+        oList = zip(op.sort_columns, op.ascending)
+        sortedList = list(it)
+        for o in oList:
+            sortedList = sorted(
+                sortedList, key=lambda x: x[o[0]], reverse=not o[1])
+        return iter(sortedList)
+
     @staticmethod
     def singletonrelation(op):
         return iter([()])
@@ -445,7 +454,7 @@ class FakeDatabase(Catalog):
                 for t in self.naryjoin(op))
 
     def myriainmemoryorderby(self, op):
-        return self.evaluate(op.input)
+        return self.orderby(op)
 
     def myriahypercubeshuffleconsumer(self, op):
         return self.evaluate(op.input)

--- a/raco/myrial/interpreter.py
+++ b/raco/myrial/interpreter.py
@@ -255,7 +255,7 @@ class ExpressionProcessor(object):
 
         if orderby_clause:
             if limit_clause is None:
-                raise Exception(
+                raise InvalidStatementException(
                     "An ORDER BY clause must be accompanied by a LIMIT clause")
             orderbyTuples = zip(*orderby_clause)
             op = raco.algebra.OrderBy(input=op,
@@ -264,7 +264,7 @@ class ExpressionProcessor(object):
 
         if limit_clause:
             if orderby_clause is None:
-                raise Exception(
+                raise InvalidStatementException(
                     "A LIMIT clause must be accompanied by an ORDER BY clause")
             op = raco.algebra.Limit(input=op, count=limit_clause)
 

--- a/raco/myrial/interpreter.py
+++ b/raco/myrial/interpreter.py
@@ -237,7 +237,9 @@ class ExpressionProcessor(object):
         if orderby_clause:
             orderbyTuples = zip(*orderby_clause)
             if orderby_clause:
-                op = raco.algebra.OrderBy(input=op, sort_columns=orderbyTuples[0], ascending=orderbyTuples[1])
+                op = raco.algebra.OrderBy(input=op,
+                                          sort_columns=orderbyTuples[0],
+                                          ascending=orderbyTuples[1])
 
         emit_args = [(name, multiway.rewrite_refs(sexpr, from_args, info))
                      for (name, sexpr) in emit_args]

--- a/raco/myrial/interpreter.py
+++ b/raco/myrial/interpreter.py
@@ -249,16 +249,20 @@ class ExpressionProcessor(object):
             if (len(from_args) == 1 and len(emit_clause) == 1 and
                 isinstance(emit_clause[0],
                            (TableWildcardEmitArg, FullWildcardEmitArg))):
-                return op
+                op = op
             op = raco.algebra.Apply(emit_args, op)
 
         if orderby_clause:
+            if limit_clause is None:
+                raise Exception("Order By queries must use the Limit operator")
             orderbyTuples = zip(*orderby_clause)
             op = raco.algebra.OrderBy(input=op,
                                       sort_columns=orderbyTuples[0],
                                       ascending=orderbyTuples[1])
 
         if limit_clause:
+            if orderby_clause is None:
+                raise Exception("Limit queries must use the Order By operator")
             op = raco.algebra.Limit(input=op, count=limit_clause)
 
         return op

--- a/raco/myrial/interpreter.py
+++ b/raco/myrial/interpreter.py
@@ -145,7 +145,7 @@ class ExpressionProcessor(object):
 
     def select(self, args):
         """Evaluate a select-from-where expression."""
-        op = self.bagcomp(args.from_, args.where, args.select)
+        op = self.bagcomp(args.from_, args.where, None, args.select)
         if args.distinct:
             op = raco.algebra.Distinct(input=op)
         if args.limit is not None:

--- a/raco/myrial/interpreter.py
+++ b/raco/myrial/interpreter.py
@@ -245,11 +245,11 @@ class ExpressionProcessor(object):
                                          statemods)
         else:
             if statemods:
-                op = raco.algebra.StatefulApply(emit_args, statemods, op)
+                return raco.algebra.StatefulApply(emit_args, statemods, op)
             if (len(from_args) == 1 and len(emit_clause) == 1 and
                 isinstance(emit_clause[0],
                            (TableWildcardEmitArg, FullWildcardEmitArg))):
-                op = op
+                return op
             op = raco.algebra.Apply(emit_args, op)
 
         if orderby_clause:

--- a/raco/myrial/interpreter.py
+++ b/raco/myrial/interpreter.py
@@ -145,11 +145,10 @@ class ExpressionProcessor(object):
 
     def select(self, args):
         """Evaluate a select-from-where expression."""
-        op = self.bagcomp(args.from_, args.where, args.orderby, args.select)
+        op = self.bagcomp(args.from_, args.where,
+                          args.select, args.orderby, args.limit)
         if args.distinct:
             op = raco.algebra.Distinct(input=op)
-        if args.limit is not None:
-            op = raco.algebra.Limit(input=op, count=args.limit)
 
         return op
 
@@ -168,7 +167,8 @@ class ExpressionProcessor(object):
                 if name not in from_args:
                     from_args[name] = self.__lookup_symbol(name)
 
-    def bagcomp(self, from_clause, where_clause, orderby_clause, emit_clause):
+    def bagcomp(self, from_clause, where_clause, emit_clause,
+                orderby_clause, limit_clause):
         """Evaluate a bag comprehension.
 
         from_clause: A list of tuples of the form (id, expr).  expr can
@@ -257,6 +257,10 @@ class ExpressionProcessor(object):
             op = raco.algebra.OrderBy(input=op,
                                       sort_columns=orderbyTuples[0],
                                       ascending=orderbyTuples[1])
+
+        if limit_clause:
+            op = raco.algebra.Limit(input=op, count=limit_clause)
+
         return op
 
     def distinct(self, expr):

--- a/raco/myrial/interpreter.py
+++ b/raco/myrial/interpreter.py
@@ -168,13 +168,15 @@ class ExpressionProcessor(object):
                 if name not in from_args:
                     from_args[name] = self.__lookup_symbol(name)
 
-    def bagcomp(self, from_clause, where_clause, emit_clause):
+    def bagcomp(self, from_clause, where_clause, orderby_clause, emit_clause):
         """Evaluate a bag comprehension.
 
         from_clause: A list of tuples of the form (id, expr).  expr can
         be None, which means "read the value from the symbol table".
 
         where_clause: An optional scalar expression (raco.expression).
+
+        orderby_clause: An optional list of OrderbyArg instances.
 
         emit_clause: A list of EmitArg instances, each defining one or more
         output columns.
@@ -231,6 +233,11 @@ class ExpressionProcessor(object):
             # to be checked
             where_clause.typeof(op.scheme(), None)
             op = raco.algebra.Select(condition=where_clause, input=op)
+
+        if orderby_clause:
+            orderbyTuples = zip(*orderby_clause)
+            if orderby_clause:
+                op = raco.algebra.OrderBy(input=op, sort_columns=orderbyTuples[0], ascending=orderbyTuples[1])
 
         emit_args = [(name, multiway.rewrite_refs(sexpr, from_args, info))
                      for (name, sexpr) in emit_args]

--- a/raco/myrial/parser.py
+++ b/raco/myrial/parser.py
@@ -753,9 +753,8 @@ class Parser(object):
     @staticmethod
     def p_expression_bagcomp(p):
         'expression : LBRACKET FROM from_arg_list opt_where_clause \
-        opt_orderby_clause \
-        EMIT emit_arg_list RBRACKET'
-        p[0] = ('BAGCOMP', p[3], p[4], p[5], p[7])
+        EMIT emit_arg_list opt_orderby_clause opt_limit RBRACKET'
+        p[0] = ('BAGCOMP', p[3], p[4], p[6], p[7], p[8])
 
     @staticmethod
     def p_from_arg_list(p):

--- a/raco/myrial/parser.py
+++ b/raco/myrial/parser.py
@@ -752,8 +752,9 @@ class Parser(object):
     @staticmethod
     def p_expression_bagcomp(p):
         'expression : LBRACKET FROM from_arg_list opt_where_clause \
+        opt_orderby_clause \
         EMIT emit_arg_list RBRACKET'
-        p[0] = ('BAGCOMP', p[3], p[4], p[6])
+        p[0] = ('BAGCOMP', p[3], p[4], p[5], p[7])
 
     @staticmethod
     def p_from_arg_list(p):
@@ -790,6 +791,36 @@ class Parser(object):
             p[0] = p[2]
         else:
             p[0] = None
+
+    @staticmethod
+    def p_opt_orderby_clause(p):
+        """opt_orderby_clause : ORDERBY orderby_arg_list
+                              | empty"""
+        if len(p) == 3:
+            p[0] = p[2]
+        else:
+            p[0] = None
+
+    @staticmethod
+    def p_explicit_orderby_list(p):
+        """orderby_arg_list : orderby_arg_list COMMA orderby_arg
+                            | orderby_arg"""
+        if len(p) == 4:
+            p[0] = p[1] + (p[3],)
+        else:
+            p[0] = (p[1],)
+
+    @staticmethod
+    def p_explicit_orderby_explicit(p):
+        """orderby_arg : column_ref ASC
+                        | column_ref DESC
+                        | column_ref"""
+        if len(p) == 3 and p[2] == 'ASC':
+            p[0] = (p[1],True)
+        if len(p) == 3 and p[2] == 'DESC':
+            p[0] = (p[1],False)
+        else:
+            p[0] = (p[1],True)
 
     @staticmethod
     def p_emit_arg_list(p):

--- a/raco/myrial/parser.py
+++ b/raco/myrial/parser.py
@@ -27,7 +27,8 @@ class JoinColumnCountMismatchException(Exception):
 JoinTarget = collections.namedtuple('JoinTarget', ['expr', 'columns'])
 
 SelectFromWhere = collections.namedtuple(
-    'SelectFromWhere', ['distinct', 'select', 'from_', 'where', 'limit'])
+    'SelectFromWhere', ['distinct', 'select', 'from_',
+                        'where', 'orderby', 'limit'])
 
 DecomposableAgg = collections.namedtuple(
     'DecomposableAgg', ['logical', 'local', 'remote'])
@@ -811,7 +812,7 @@ class Parser(object):
             p[0] = (p[1],)
 
     @staticmethod
-    def p_explicit_orderby_explicit(p):
+    def p_explicit_orderby_arg(p):
         """orderby_arg : column_ref ASC
                         | column_ref DESC
                         | column_ref"""
@@ -876,9 +877,11 @@ class Parser(object):
 
     @staticmethod
     def p_select_from_where(p):
-        'select_from_where : SELECT opt_distinct emit_arg_list FROM from_arg_list opt_where_clause opt_limit'  # noqa
+        'select_from_where : SELECT opt_distinct emit_arg_list FROM from_arg_list \
+         opt_where_clause opt_orderby_clause opt_limit'  # noqa
         p[0] = ('SELECT', SelectFromWhere(distinct=p[2], select=p[3],
-                                          from_=p[5], where=p[6], limit=p[7]))
+                                          from_=p[5], where=p[6],
+                                          orderby=p[7], limit=p[8]))
 
     @staticmethod
     def p_opt_distinct(p):

--- a/raco/myrial/parser.py
+++ b/raco/myrial/parser.py
@@ -816,11 +816,11 @@ class Parser(object):
                         | column_ref DESC
                         | column_ref"""
         if len(p) == 3 and p[2] == 'ASC':
-            p[0] = (p[1],True)
+            p[0] = (p[1], True)
         if len(p) == 3 and p[2] == 'DESC':
-            p[0] = (p[1],False)
+            p[0] = (p[1], False)
         else:
-            p[0] = (p[1],True)
+            p[0] = (p[1], True)
 
     @staticmethod
     def p_emit_arg_list(p):

--- a/raco/myrial/query_tests.py
+++ b/raco/myrial/query_tests.py
@@ -618,6 +618,28 @@ class TestQueryFunctions(myrial_test.MyrialTestCase, FakeData):
         with self.assertRaises(Exception):  # noqa
             self.check_result(query, None)
 
+    def test_limit_orderby(self):
+        query = """
+        out = [FROM SCAN(%s) as X EMIT * ORDER BY $0 ASC LIMIT 3];
+        STORE(out, OUTPUT);
+        """ % self.emp_key
+
+        result = self.execute_query(query)
+        expectedResult = collections.Counter(
+            sorted(self.emp_table.elements(), key=lambda emp: emp[0])[:3])
+        self.assertEquals(result, expectedResult)
+
+    def test_sql_limit_orderby(self):
+        query = """
+        out = SELECT * FROM SCAN(%s) as X ORDER BY $0 ASC LIMIT 3;
+        STORE(out, OUTPUT);
+        """ % self.emp_key
+
+        result = self.execute_query(query)
+        expectedResult = collections.Counter(
+            sorted(self.emp_table.elements(), key=lambda emp: emp[0])[:3])
+        self.assertEquals(result, expectedResult)
+
     def test_table_literal_boolean(self):
         query = """
         X = [truE as MyTrue, FaLse as MyFalse];

--- a/raco/myrial/query_tests.py
+++ b/raco/myrial/query_tests.py
@@ -618,30 +618,6 @@ class TestQueryFunctions(myrial_test.MyrialTestCase, FakeData):
         with self.assertRaises(Exception):  # noqa
             self.check_result(query, None)
 
-    def test_limit_orderby(self):
-        query = """
-        out = [FROM SCAN(%s) as X EMIT * ORDER BY $0 ASC LIMIT 3];
-        STORE(out, OUTPUT);
-        """ % self.emp_key
-
-        result = self.execute_query(query)
-        expectedResult = sorted(self.emp_table.elements(),
-                                key=lambda emp: emp[0])[:3]
-
-        self.assertEquals(result, expectedResult)
-
-    def test_sql_limit_orderby(self):
-        query = """
-        out = SELECT * FROM SCAN(%s) as X ORDER BY $0 ASC LIMIT 3;
-        STORE(out, OUTPUT);
-        """ % self.emp_key
-
-        result = self.execute_query(query)
-        expectedResult = sorted(self.emp_table.elements(),
-                                key=lambda emp: emp[0])[:3]
-
-        self.assertEquals(result, expectedResult)
-
     def test_table_literal_boolean(self):
         query = """
         X = [truE as MyTrue, FaLse as MyFalse];

--- a/raco/myrial/query_tests.py
+++ b/raco/myrial/query_tests.py
@@ -640,6 +640,40 @@ class TestQueryFunctions(myrial_test.MyrialTestCase, FakeData):
             sorted(self.emp_table.elements(), key=lambda emp: emp[0])[:3])
         self.assertEquals(result, expectedResult)
 
+    def test_limit_orderby_multikey(self):
+        query = """
+        out = [FROM SCAN(%s) as X EMIT *
+               ORDER BY $1 ASC, $3 DESC, $2 ASC
+               LIMIT 3];
+        STORE(out, OUTPUT);
+        """ % self.emp_key
+
+        result = self.execute_query(query)
+
+        firstSort = sorted(self.emp_table.elements(), key=lambda emp: emp[2])
+        secondSort = sorted(firstSort, key=lambda emp: emp[3], reverse=True)
+        thirdSortLimit = sorted(secondSort, key=lambda emp: emp[1])[:3]
+        expectedResult = collections.Counter(thirdSortLimit)
+
+        self.assertEquals(result, expectedResult)
+
+    def test_sql_limit_orderby_multikey(self):
+        query = """
+        out = SELECT * FROM SCAN(%s) as X
+              ORDER BY $1 ASC, $3 DESC, $2 ASC
+              LIMIT 3;
+        STORE(out, OUTPUT);
+        """ % self.emp_key
+
+        result = self.execute_query(query)
+
+        firstSort = sorted(self.emp_table.elements(), key=lambda emp: emp[2])
+        secondSort = sorted(firstSort, key=lambda emp: emp[3], reverse=True)
+        thirdSortLimit = sorted(secondSort, key=lambda emp: emp[1])[:3]
+        expectedResult = collections.Counter(thirdSortLimit)
+
+        self.assertEquals(result, expectedResult)
+
     def test_table_literal_boolean(self):
         query = """
         X = [truE as MyTrue, FaLse as MyFalse];

--- a/raco/myrial/query_tests.py
+++ b/raco/myrial/query_tests.py
@@ -600,23 +600,47 @@ class TestQueryFunctions(myrial_test.MyrialTestCase, FakeData):
         expected = collections.Counter([(x[3],) for x in self.emp_table])
         self.check_result(query, expected)
 
-    def test_limit(self):
+    def test_limit_without_orderby_assert(self):
         query = """
         out = LIMIT(SCAN(%s), 3);
         STORE(out, OUTPUT);
         """ % self.emp_key
 
-        result = self.execute_query(query)
-        self.assertEquals(len(result), 3)
+        with self.assertRaises(Exception):  # noqa
+            self.check_result(query, None)
 
-    def test_sql_limit(self):
+    def test_orderby_without_limit_assert(self):
         query = """
-        out = SELECT * FROM SCAN(%s) as X LIMIT 3;
+        out = SELECT * FROM SCAN(%s) as X ORDER BY $0;
+        STORE(out, OUTPUT);
+        """ % self.emp_key
+
+        with self.assertRaises(Exception):  # noqa
+            self.check_result(query, None)
+
+    def test_limit_orderby(self):
+        query = """
+        out = [FROM SCAN(%s) as X EMIT * ORDER BY $0 ASC LIMIT 3];
         STORE(out, OUTPUT);
         """ % self.emp_key
 
         result = self.execute_query(query)
-        self.assertEquals(len(result), 3)
+        expectedResult = sorted(self.emp_table.elements(),
+                                key=lambda emp: emp[0])[:3]
+
+        self.assertEquals(result, expectedResult)
+
+    def test_sql_limit_orderby(self):
+        query = """
+        out = SELECT * FROM SCAN(%s) as X ORDER BY $0 ASC LIMIT 3;
+        STORE(out, OUTPUT);
+        """ % self.emp_key
+
+        result = self.execute_query(query)
+        expectedResult = sorted(self.emp_table.elements(),
+                                key=lambda emp: emp[0])[:3]
+
+        self.assertEquals(result, expectedResult)
 
     def test_table_literal_boolean(self):
         query = """

--- a/raco/myrial/scanner.py
+++ b/raco/myrial/scanner.py
@@ -9,11 +9,11 @@ keywords = ['WHILE', 'DO', 'DEF', 'APPLY', 'CASE', 'WHEN', 'THEN',
             'ELSE', 'END', 'CONST', 'LOAD', 'DUMP', 'CSV', 'SCHEMA',
             'OPP', 'TIPSY', 'UDA', 'TRUE', 'FALSE', 'HASH', 'BROADCAST',
             'ROUND_ROBIN', 'UNTIL', 'CONVERGENCE', "SYNC", "ASYNC",
-            'ALTERNATE', 'PULL_IDB', 'PULL_EDB', 'BUILD_EDB']
+            'ALTERNATE', 'PULL_IDB', 'PULL_EDB', 'BUILD_EDB', 'ASC', 'DESC']
 
 types = ['INT', 'STRING', 'FLOAT', 'BOOLEAN', 'BLOB']
 
-comprehension_keywords = ['SELECT', 'AS', 'EMIT', 'FROM', 'WHERE']
+comprehension_keywords = ['SELECT', 'AS', 'EMIT', 'FROM', 'WHERE', 'ORDERBY']
 
 word_operators = ['AND', 'OR', 'NOT']
 

--- a/raco/myrial/scanner.py
+++ b/raco/myrial/scanner.py
@@ -71,6 +71,14 @@ t_LARROW = r'<-'
 # Regular expressions for non-trivial tokens
 
 
+def t_ORDERBY(t):
+    r'ORDER\s+BY'
+    # remove spaces
+    value = ''.join(x for x in t.value if not x.isspace())
+    t.value = value
+    return t
+
+
 def t_BLOB_LITERAL(t):
     r'b((\'(\\x[0-9a-fA-F]{2})*\')|(\"(\\x[0-9a-fA-F]{2})*\"))'
     t.value = bytes(t.value[2:-1].decode("string_escape"))


### PR DESCRIPTION
* added support for OrderBy in Myrial (but must be paired with a Limit operator). Can support queries with this syntax:

```
T1 = [from scan(TwitterK) as t ORDERBY $0 ASC, $1 DESC emit *];
T2 = LIMIT(T1,50);
store(T2, TwitterKOrdered);)
```

I wasn't sure if we wanted to use the `ASC` or `DESC` keywords in MyriaL, but I added them there for now. If neither `ASC` or `DESC` are described, we order ascending by default.

* added new rule to push a Collect operator below the OrderBy