### PR TITLE
apply lists of rules recursively

### DIFF
--- a/raco/backends/cpp/cpp.py
+++ b/raco/backends/cpp/cpp.py
@@ -596,10 +596,7 @@ class CCAlgebra(Algebra):
         if kwargs.get('external_indexing'):
             CBaseLanguage.set_external_indexing(True)
 
-        # flatten the rules lists
-        rule_list = list(itertools.chain(*rule_grps_sequence))
+        for rule_list in rule_grps_sequence:
+            rules.Rule.apply_disable_flags(rule_list, *kwargs.keys())
 
-        # disable specified rules
-        rules.Rule.apply_disable_flags(rule_list, *kwargs.keys())
-
-        return rule_list
+        return rule_grps_sequence

--- a/raco/backends/logical.py
+++ b/raco/backends/logical.py
@@ -6,16 +6,9 @@ class OptLogicalAlgebra(Algebra):
 
     @staticmethod
     def opt_rules(**kwargs):
-        return [rules.RemoveTrivialSequences(),
-                rules.SimpleGroupBy(),
-                rules.SplitSelects(),
-                rules.PushSelects(),
-                rules.MergeSelects(),
-                rules.ProjectToDistinctColumnSelect(),
-                rules.JoinToProjectingJoin(),
-                rules.PushApply(),
-                rules.RemoveUnusedColumns(),
-                rules.PushApply(),
-                rules.RemoveUnusedColumns(),
-                rules.PushApply(),
-                rules.DeDupBroadcastInputs()]
+        return [rules.remove_trivial_sequences,
+                rules.simple_group_by,
+                rules.push_select,
+                rules.push_project,
+                rules.push_apply,
+                [rules.DeDupBroadcastInputs()]]

--- a/raco/backends/myria/myria.py
+++ b/raco/backends/myria/myria.py
@@ -1524,7 +1524,8 @@ class HCShuffleBeforeNaryJoin(rules.Rule):
         if not isinstance(expr, algebra.NaryJoin):
             return expr
         # check if HC shuffle has been placed before
-        shuffled_child = [isinstance(op, algebra.HyperCubeShuffle)
+        shuffled_child = [isinstance(op, algebra.HyperCubeShuffle) or
+                          isinstance(op, algebra.OrderBy)
                           for op in list(expr.children())]
         if all(shuffled_child):    # already shuffled
             assert len(expr.children()) > 0
@@ -1730,6 +1731,8 @@ class InsertSplit(rules.Rule):
         """Walk the tree starting from op and insert a split when we
         encounter a heavyweight operator."""
         if isinstance(op, MyriaAlgebra.fragment_leaves):
+            return op
+        if isinstance(op, algebra.Split):
             return op
 
         if isinstance(op, InsertSplit.heavy_ops):
@@ -2197,13 +2200,11 @@ class MyriaLeftDeepTreeAlgebra(MyriaAlgebra):
 
         rule_grps_sequence = opt_grps_sequence + compile_grps_sequence
 
-        # flatten the rules lists
-        rule_list = list(itertools.chain(*rule_grps_sequence))
-
         # disable specified rules
-        rules.Rule.apply_disable_flags(rule_list, *kwargs.keys())
+        for l in rule_grps_sequence:
+            rules.Rule.apply_disable_flags(l, *kwargs.keys())
 
-        return rule_list
+        return rule_grps_sequence
 
 
 class MyriaHyperCubeAlgebra(MyriaAlgebra):
@@ -2261,13 +2262,11 @@ class MyriaHyperCubeAlgebra(MyriaAlgebra):
 
         rule_grps_sequence = opt_grps_sequence + compile_grps_sequence
 
-        # flatten the rules lists
-        rule_list = list(itertools.chain(*rule_grps_sequence))
-
         # disable specified rules
-        rules.Rule.apply_disable_flags(rule_list, *kwargs.keys())
+        for l in rule_grps_sequence:
+            rules.Rule.apply_disable_flags(l, *kwargs.keys())
 
-        return rule_list
+        return rule_grps_sequence
 
     def __init__(self, catalog=None):
         self.catalog = catalog

--- a/raco/backends/radish/radish.py
+++ b/raco/backends/radish/radish.py
@@ -2552,10 +2552,8 @@ class GrappaAlgebra(Algebra):
         if external_indexing:
             CBaseLanguage.set_external_indexing(True)
 
-        # flatten the rules lists
-        rule_list = list(itertools.chain(*rule_grps_sequence))
-
         # disable specified rules
-        rules.Rule.apply_disable_flags(rule_list, *kwargs.keys())
+        for rule_list in rule_grps_sequence:
+            rules.Rule.apply_disable_flags(rule_list, *kwargs.keys())
 
-        return rule_list
+        return rule_grps_sequence

--- a/raco/backends/sparql/sparql.py
+++ b/raco/backends/sparql/sparql.py
@@ -152,7 +152,7 @@ class SPARQLApply(algebra.Apply, SPARQLOperator):
 class SPARQLAlgebra(Algebra):
 
     def opt_rules(self, **kwargs):
-        rules = [
+        rules = [[
             raco.rules.CrossProduct2Join(),
             raco.rules.SplitSelects(),
             raco.rules.PushSelects(),
@@ -162,6 +162,6 @@ class SPARQLAlgebra(Algebra):
             raco.rules.OneToOne(algebra.Select, SPARQLSelect),
             raco.rules.OneToOne(algebra.Apply, SPARQLApply),
             raco.rules.OneToOne(algebra.Join, SPARQLJoin),
-        ]
+        ]]
 
         return rules


### PR DESCRIPTION
An algebra was defined as a list of lists of rules but then got flattened. This limits recursive optimizations that consist of multiple rules, for example, PushApply + RemoveUnusedColumn were repeated twice, which still produces redundant columns if the query contains more than two joins. This PR removes the flattening and applied a list of rules recursively until no change. It fixes the PushApply + RemoveUnusedColumn problem and also several bugs disclosed by this change.