### PR TITLE
Export to S3 via MyriaL

### DIFF
--- a/raco/algebra.py
+++ b/raco/algebra.py
@@ -1576,6 +1576,33 @@ class Store(UnaryOperator):
         UnaryOperator.copy(self, other)
 
 
+class Export(UnaryOperator):
+
+    """ export tuples to S3."""
+
+    def __init__(self, uri=None, plan=None):
+        UnaryOperator.__init__(self, plan)
+        self.uri = uri
+
+    def num_tuples(self):
+        return self.input.num_tuples()
+
+    def partitioning(self):
+        return self.input.partitioning()
+
+    def shortStr(self):
+        return "%s(%s)" % (self.opname(), self.uri)
+
+    def __repr__(self):
+        return "{op}({u!r},{pl!r})".format(op=self.opname(),
+                                           u=self.uri,
+                                           pl=self.plan)
+
+    def copy(self, other):
+        self.uri = other.uri
+        UnaryOperator.copy(self, other)
+
+
 class Dump(UnaryOperator):
 
     """Echo input to standard out; only useful for standalone raco."""

--- a/raco/backends/myria/myria.py
+++ b/raco/backends/myria/myria.py
@@ -388,6 +388,17 @@ class MyriaSink(algebra.Sink, MyriaOperator):
         }
 
 
+class MyriaExport(algebra.Export, MyriaOperator):
+
+    def compileme(self, inputid):
+        return {
+            "opType": "TupleSink",
+            "tupleWriter": {"writerType": "CSV"},
+            "dataSink": {"uri": self.uri, "dataType": "Uri"},
+            "argChild": inputid,
+        }
+
+
 class MyriaAppendTemp(algebra.AppendTemp, MyriaOperator):
 
     def compileme(self, inputid):
@@ -1856,6 +1867,7 @@ myriafy = [
     rules.OneToOne(algebra.CrossProduct, MyriaCrossProduct),
     rules.OneToOne(algebra.Store, MyriaStore),
     rules.OneToOne(algebra.StoreTemp, MyriaStoreTemp),
+    rules.OneToOne(algebra.Export, MyriaExport),
     rules.OneToOne(algebra.StatefulApply, MyriaStatefulApply),
     rules.OneToOne(algebra.Apply, MyriaApply),
     rules.OneToOne(algebra.Select, MyriaSelect),
@@ -2430,7 +2442,7 @@ def compile_to_json(raw_query, logical_plan, physical_plan,
     string and passed along unchanged."""
 
     # Store/StoreTemp is a reasonable physical plan... for now.
-    root_ops = (algebra.Store, algebra.StoreTemp, algebra.Sink)
+    root_ops = (algebra.Store, algebra.StoreTemp, algebra.Sink, algebra.Export)
     if isinstance(physical_plan, root_ops):
         physical_plan = algebra.Parallel([physical_plan])
 

--- a/raco/myrial/interpreter.py
+++ b/raco/myrial/interpreter.py
@@ -438,6 +438,15 @@ class StatementProcessor(object):
         uses_set = self.ep.get_and_clear_uses_set()
         self.cfg.add_op(op, None, uses_set)
 
+    def export(self, _id, uri):
+        alias_expr = ("ALIAS", _id)
+        child_op = self.ep.evaluate(alias_expr)
+        collect_op = raco.algebra.Collect(child_op)
+        op = raco.algebra.Export(uri, collect_op)
+
+        uses_set = self.ep.get_and_clear_uses_set()
+        self.cfg.add_op(op, None, uses_set)
+
     def dump(self, _id):
         alias_expr = ("ALIAS", _id)
         child_op = self.ep.evaluate(alias_expr)

--- a/raco/myrial/parser.py
+++ b/raco/myrial/parser.py
@@ -566,6 +566,11 @@ class Parser(object):
         p[0] = ('SINK', p[3])
 
     @staticmethod
+    def p_statement_export(p):
+        'statement : EXPORT LPAREN unreserved_id COMMA STRING_LITERAL RPAREN SEMI'  # noqa
+        p[0] = ('EXPORT', p[3], p[5])
+
+    @staticmethod
     def p_statement_dump(p):
         'statement : DUMP LPAREN unreserved_id RPAREN SEMI'
         p[0] = ('DUMP', p[3])

--- a/raco/myrial/scanner.py
+++ b/raco/myrial/scanner.py
@@ -18,8 +18,8 @@ comprehension_keywords = ['SELECT', 'AS', 'EMIT', 'FROM', 'WHERE', 'ORDERBY']
 word_operators = ['AND', 'OR', 'NOT']
 
 builtins = ['EMPTY', 'WORKER_ID', 'SCAN', 'COUNTALL', 'COUNT', 'STORE',
-            'DIFF', 'CROSS', 'JOIN', 'UNION', 'UNIONALL', 'INTERSECT',
-            'DISTINCT', 'LIMIT', 'SINK', 'SAMPLESCAN', 'LIKE']
+            'EXPORT', 'DIFF', 'CROSS', 'JOIN', 'UNION', 'UNIONALL',
+            'INTERSECT', 'DISTINCT', 'LIMIT', 'SINK', 'SAMPLESCAN', 'LIKE']
 
 
 # identifiers with special meaning; case-insensitive


### PR DESCRIPTION
Adding the ability to export relations to S3 via MyriaL. This is not a parallel export. All workers shuffle their data to one worker before sending to S3.

By default, the relation exports in CSV format. Should we make that configurable?

Example query:

```
t = load("https://s3-us-west-2.amazonaws.com/uwdb/sampleData/TwitterK.csv", csv(schema(column0:int, column1:int), skip=1));
export(t, 's3://elastic-cluster-test/testExport');
```